### PR TITLE
Make brpc support GCC 4.4.7, tested on Ubuntu 12.04 LTS.

### DIFF
--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -39,7 +39,7 @@ elif [ -z "$CXX" ]; then
 fi
 
 GCC_VERSION=$($CXX tools/print_gcc_version.cc -o print_gcc_version && ./print_gcc_version && rm ./print_gcc_version)
-if [ $GCC_VERSION -gt 0 ] && [ $GCC_VERSION -lt 40800 ]; then
+if [ $GCC_VERSION -gt 0 ] && [ $GCC_VERSION -lt 40407 ]; then
     >&2 $ECHO "GCC is too old, please install a newer version supporting C++11"
     exit 1
 fi

--- a/src/brpc/input_messenger.cpp
+++ b/src/brpc/input_messenger.cpp
@@ -128,8 +128,10 @@ ParseResult InputMessenger::CutInputMessage(
 }
 
 void* ProcessInputMessage(void* void_arg) {
-    InputMessageBase* msg = static_cast<InputMessageBase*>(void_arg);
-    msg->_process(msg);
+    if (void_arg != NULL) {
+        InputMessageBase* msg = static_cast<InputMessageBase*>(void_arg);
+        msg->_process(msg);
+    }
     return NULL;
 }
 

--- a/src/butil/at_exit.cc
+++ b/src/butil/at_exit.cc
@@ -48,7 +48,7 @@ void AtExitManager::RegisterCallback(AtExitCallbackType func, void* param) {
   }
 
   AutoLock lock(g_top_manager->lock_);
-  g_top_manager->stack_.push({func, param});
+  g_top_manager->stack_.push(Callback{func, param});
 }
 
 // static

--- a/src/butil/atomicops.h
+++ b/src/butil/atomicops.h
@@ -281,7 +281,17 @@ private:
 
 #define BASE_STATIC_ATOMIC_INIT(val) { (val) }
 
+// std::atomic<_Tp*>::store() is declared but not implemented until GCC 4.5.2
+#if GCC_VERSION < 40502
+namespace std {
+template<typename _Tp>
+void atomic<_Tp*>::store(_Tp* __p, memory_order __m) volatile
+{ atomic_address::store(__p, __m); }
+}  // namespace std
+#endif  // GCC_VERSION < 40502
+
 namespace butil {
+
 template <typename T> struct static_atomic {
     T val;
 

--- a/src/butil/build_config.h
+++ b/src/butil/build_config.h
@@ -165,6 +165,9 @@
 #define BASE_STRING16_ITERATOR_IS_CHAR16_POINTER
 #endif
 
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
 #if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
 #define BASE_CXX11_ENABLED 1
 #endif

--- a/src/butil/compiler_specific.h
+++ b/src/butil/compiler_specific.h
@@ -272,7 +272,8 @@
 #endif
 
 #ifndef BAIDU_NOEXCEPT
-# if defined(BASE_CXX11_ENABLED)
+// "noexcept" keyword was supported since GCC 4.6
+# if defined(BASE_CXX11_ENABLED) && GCC_VERSION >= 40600
 #  define BAIDU_NOEXCEPT noexcept
 # else
 #  define BAIDU_NOEXCEPT

--- a/src/butil/intrusive_ptr.hpp
+++ b/src/butil/intrusive_ptr.hpp
@@ -147,7 +147,8 @@ public:
     }
 
     // implicit conversion to "bool"
-#if defined(BASE_CXX11_ENABLED)
+// "explicit conversion operators" was supported since GCC 4.5
+#if defined(BASE_CXX11_ENABLED) && GCC_VERSION >= 40500
     explicit operator bool () const BAIDU_NOEXCEPT {
         return px != 0;
     }
@@ -220,7 +221,8 @@ inline bool operator!=(const intrusive_ptr<T>& a, const intrusive_ptr<T>& b) {
 }
 #endif
 
-#if defined(BASE_CXX11_ENABLED)
+// "null pointer constant" was supported since GCC 4.6
+#if defined(BASE_CXX11_ENABLED) && GCC_VERSION >= 40600
 template<class T>
 inline bool operator==(const intrusive_ptr<T>& p, std::nullptr_t) BAIDU_NOEXCEPT {
     return p.get() == 0;

--- a/src/butil/scoped_lock.h
+++ b/src/butil/scoped_lock.h
@@ -28,7 +28,8 @@
 #include "butil/logging.h"
 #include "butil/errno.h"
 
-#if !defined(BASE_CXX11_ENABLED)
+// "decltype and call expressions" was supported since GCC 4.8.1
+#if !defined(BASE_CXX11_ENABLED) || GCC_VERSION < 40801
 #define BAIDU_SCOPED_LOCK(ref_of_lock)                                  \
     std::lock_guard<BAIDU_TYPEOF(ref_of_lock)>                          \
     BAIDU_CONCAT(scoped_locker_dummy_at_line_, __LINE__)(ref_of_lock)


### PR DESCRIPTION
This patch makes example/echo_c++ work on Ubuntu 12.04 with GCC 4.4.7.