### PR TITLE
Improve cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.10)
 project(brpc C CXX)
 
+set(BRPC_VERSION 0.9.0)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # require at least gcc 4.8
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
@@ -131,8 +133,10 @@ set(DYNAMIC_LIB
     dl
     z
     )
+set(BRPC_PRIVATE_LIBS "-lgflags -lprotobuf -lleveldb -lprotoc -lrt -lssl -lcrypto -ldl -lz")
 if(BRPC_WITH_GLOG)
     set(DYNAMIC_LIB ${DYNAMIC_LIB} ${GLOG_LIB})
+    set(BRPC_PRIVATE_LIBS "${BRPC_PRIVATE_LIBS} -lglog")
 endif()
 
 # for *.so
@@ -344,3 +348,7 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/output/include/
         PATTERN "*.h"
         PATTERN "*.hpp"
         )
+
+# Install pkgconfig
+configure_file(cmake/brpc.pc.in ${CMAKE_BINARY_DIR}/brpc.pc @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/brpc.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ if(WITH_DEBUG_SYMBOLS)
     set(DEBUG_SYMBOL "-g")
 endif()
 
+include(GNUInstallDirs)
+
 configure_file(${CMAKE_SOURCE_DIR}/config.h.in ${CMAKE_SOURCE_DIR}/src/butil/config.h @ONLY)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
@@ -337,7 +339,7 @@ file(COPY ${CMAKE_SOURCE_DIR}/src/
         PATTERN "*.hpp"
         )
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/output/include/
-        DESTINATION include
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING
         PATTERN "*.h"
         PATTERN "*.hpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,36 +282,31 @@ set(MCPACK2PB_SOURCES
     ${CMAKE_SOURCE_DIR}/src/mcpack2pb/serializer.cpp
     )
 
-file(GLOB PROTOS "${CMAKE_SOURCE_DIR}/src/*.proto")
-list(APPEND PROTO_FLAGS -I${CMAKE_CURRENT_BINARY_DIR})
-foreach(PROTO ${PROTOS})
-    get_filename_component(PROTO_WE ${PROTO} NAME_WE)
-    list(APPEND PROTO_SRCS "${CMAKE_CURRENT_BINARY_DIR}/${PROTO_WE}.pb.cc")
-    execute_process(
-        COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} ${PROTO_FLAGS} --cpp_out=${CMAKE_CURRENT_BINARY_DIR} --proto_path=${PROTOBUF_INCLUDE_DIR} --proto_path=${CMAKE_SOURCE_DIR}/src ${PROTO}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-endforeach()
-
-file(GLOB BRPC_PROTOS "src/brpc/*.proto")
-foreach(PROTO ${BRPC_PROTOS})
-    get_filename_component(PROTO_WE ${PROTO} NAME_WE)
-    list(APPEND PROTO_SRCS "${CMAKE_CURRENT_BINARY_DIR}/brpc/${PROTO_WE}.pb.cc")
-    execute_process(
-        COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} ${PROTO_FLAGS} --cpp_out=${CMAKE_CURRENT_BINARY_DIR} --proto_path=${PROTOBUF_INCLUDE_DIR} --proto_path=${CMAKE_SOURCE_DIR}/src --proto_path=${CMAKE_SOURCE_DIR}/src/brpc/ ${PROTO}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-endforeach()
-
-file(GLOB BRPC_POLICY_PROTOS "src/brpc/policy/*.proto")
-foreach(PROTO ${BRPC_POLICY_PROTOS})
-    get_filename_component(PROTO_WE ${PROTO} NAME_WE)
-    list(APPEND PROTO_SRCS "${CMAKE_CURRENT_BINARY_DIR}/brpc/policy/${PROTO_WE}.pb.cc")
-    execute_process(
-        COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} ${PROTO_FLAGS} --cpp_out=${CMAKE_CURRENT_BINARY_DIR} --proto_path=${PROTOBUF_INCLUDE_DIR} --proto_path=${CMAKE_SOURCE_DIR}/src --proto_path=${CMAKE_SOURCE_DIR}/src/brpc/policy ${PROTO}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-endforeach()
+include(CompileProto)
+set(PROTO_FILES idl_options.proto
+                brpc/rtmp.proto
+                brpc/rpc_dump.proto
+                brpc/get_favicon.proto
+                brpc/span.proto
+                brpc/builtin_service.proto
+                brpc/get_js.proto
+                brpc/errno.proto
+                brpc/nshead_meta.proto
+                brpc/options.proto
+                brpc/policy/baidu_rpc_meta.proto
+                brpc/policy/hulu_pbrpc_meta.proto
+                brpc/policy/public_pbrpc_meta.proto
+                brpc/policy/sofa_pbrpc_meta.proto
+                brpc/policy/mongo.proto
+                brpc/trackme.proto
+                brpc/streaming_rpc_meta.proto)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/output/include/brpc)
+set(PROTOC_FLAGS ${PROTOC_FLAGS} -I${PROTOBUF_INCLUDE_DIR})
+compile_proto(PROTO_HDRS PROTO_SRCS ${CMAKE_BINARY_DIR} 
+                                    ${CMAKE_BINARY_DIR}/output/include
+                                    ${CMAKE_SOURCE_DIR}/src 
+                                    "${PROTO_FILES}")
+add_library(PROTO_LIB OBJECT ${PROTO_SRCS} ${PROTO_HDRS})
 
 set(SOURCES
     ${BVAR_SOURCES}
@@ -319,7 +314,6 @@ set(SOURCES
     ${JSON2PB_SOURCES}
     ${MCPACK2PB_SOURCES}
     ${BRPC_SOURCES}
-    ${PROTO_SRCS}
     )
 
 add_subdirectory(src)
@@ -328,8 +322,6 @@ if(BUILD_UNIT_TESTS)
 endif()
 add_subdirectory(tools)
 
-file(COPY ${CMAKE_CURRENT_BINARY_DIR}/idl_options.pb.h
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/output/include)
 file(COPY ${CMAKE_CURRENT_BINARY_DIR}/brpc/
         DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/output/include/brpc/
         FILES_MATCHING 

--- a/cmake/CMakeLists.download_gtest.in
+++ b/cmake/CMakeLists.download_gtest.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 2.8.10)
 
 project(googletest-download NONE)
 

--- a/cmake/CMakeLists.download_gtest.in
+++ b/cmake/CMakeLists.download_gtest.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.6)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           release-1.8.0
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/cmake/CompileProto.cmake
+++ b/cmake/CompileProto.cmake
@@ -1,0 +1,19 @@
+function(compile_proto OUT_HDRS OUT_SRCS DESTDIR HDR_OUTPUT_DIR PROTO_DIR PROTO_FILES)
+  foreach(P ${PROTO_FILES})
+    string(REPLACE .proto .pb.h HDR ${P})
+    set(HDR_RELATIVE ${HDR})
+    set(HDR ${DESTDIR}/${HDR})
+    string(REPLACE .proto .pb.cc SRC ${P})
+    set(SRC ${DESTDIR}/${SRC})
+    list(APPEND HDRS ${HDR})
+    list(APPEND SRCS ${SRC})
+    add_custom_command(
+      OUTPUT ${HDR} ${SRC}
+      COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} ${PROTOC_FLAGS} -I${PROTO_DIR} --cpp_out=${DESTDIR} ${PROTO_DIR}/${P}
+      COMMAND ${CMAKE_COMMAND} -E copy ${HDR} ${HDR_OUTPUT_DIR}/${HDR_RELATIVE}
+      DEPENDS ${PROTO_DIR}/${P}
+    )
+  endforeach()
+  set(${OUT_HDRS} ${HDRS} PARENT_SCOPE)
+  set(${OUT_SRCS} ${SRCS} PARENT_SCOPE)
+endfunction()

--- a/cmake/SetupGtest.cmake
+++ b/cmake/SetupGtest.cmake
@@ -1,0 +1,24 @@
+# Setup googletest
+configure_file("${CMAKE_SOURCE_DIR}/cmake/CMakeLists.download_gtest.in" ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+                RESULT_VARIABLE result
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download
+)
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                RESULT_VARIABLE result
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download
+)
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                 ${CMAKE_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)

--- a/cmake/brpc.pc.in
+++ b/cmake/brpc.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: brpc
+Description: A industrial-grade RPC framework used throughout Baidu, with 1,000,000+ instances(not counting clients) and thousands kinds of services, called "baidu-rpc" inside Baidu.
+Version: @BRPC_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir}/ -lbrpc
+Libs.private: @BRPC_PRIVATE_LIBS@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,23 +37,15 @@ set(protoc_gen_mcpack_SOURCES
 add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
 target_link_libraries(protoc-gen-mcpack brpc-shared)
     
-get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-if ("${LIB64}" STREQUAL "TRUE")
-    set(LIBSUFFIX 64)
-else()
-    set(LIBSUFFIX "")
-endif()
-
 #install directory
-# cmake -DCMAKE_INSTALL_PREFIX=/usr
 install(TARGETS brpc-shared
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib${LIBSUFFIX}
-        ARCHIVE DESTINATION lib${LIBSUFFIX}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         )
 
 install(TARGETS brpc-static
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib${LIBSUFFIX}
-        ARCHIVE DESTINATION lib${LIBSUFFIX}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,8 +16,12 @@ add_library(OBJ_LIB OBJECT ${SOURCES})
 set_property(TARGET ${OBJ_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)
 set_property(TARGET ${BUTIL_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)
 
-add_library(brpc-shared SHARED $<TARGET_OBJECTS:BUTIL_LIB> $<TARGET_OBJECTS:OBJ_LIB>)
-add_library(brpc-static STATIC $<TARGET_OBJECTS:BUTIL_LIB> $<TARGET_OBJECTS:OBJ_LIB>)
+add_library(brpc-shared SHARED $<TARGET_OBJECTS:BUTIL_LIB> 
+                               $<TARGET_OBJECTS:OBJ_LIB>
+                               $<TARGET_OBJECTS:PROTO_LIB>)
+add_library(brpc-static STATIC $<TARGET_OBJECTS:BUTIL_LIB>
+                               $<TARGET_OBJECTS:OBJ_LIB>
+                               $<TARGET_OBJECTS:PROTO_LIB>)
 
 target_link_libraries(brpc-shared ${DYNAMIC_LIB})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,26 @@
 find_package(Gperftools)
 include_directories(${GPERFTOOLS_INCLUDE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-file(GLOB PROTOS "*.proto")
-list(APPEND PROTO_FLAGS -I${CMAKE_CURRENT_BINARY_DIR})
-foreach(PROTO ${PROTOS})
-    get_filename_component(PROTO_WE ${PROTO} NAME_WE)
-    list(APPEND TEST_PROTO_SRCS "${CMAKE_CURRENT_BINARY_DIR}/${PROTO_WE}.pb.cc")
-    execute_process(
-        COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} ${PROTO_FLAGS} --cpp_out=${CMAKE_CURRENT_BINARY_DIR} --proto_path=${PROTOBUF_INCLUDE_DIR} --proto_path=${CMAKE_SOURCE_DIR}/src --proto_path=${CMAKE_SOURCE_DIR}/test ${PROTO}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-endforeach()
+
+include(CompileProto)
+set(TEST_PROTO_FILES addressbook1.proto
+                     addressbook_encode_decode.proto
+                     addressbook_map.proto
+                     addressbook.proto
+                     echo.proto
+                     iobuf.proto
+                     message.proto
+                     repeated.proto
+                     snappy_message.proto
+                     v1.proto
+                     v2.proto)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/test/hdrs)
+set(PROTOC_FLAGS ${PROTOC_FLAGS} -I${CMAKE_SOURCE_DIR}/src)
+compile_proto(PROTO_HDRS PROTO_SRCS ${CMAKE_BINARY_DIR}/test
+                                    ${CMAKE_BINARY_DIR}/test/hdrs
+                                    ${CMAKE_SOURCE_DIR}/test
+                                    "${TEST_PROTO_FILES}")
+add_library(TEST_PROTO_LIB OBJECT ${PROTO_SRCS} ${PROTO_HDRS})
 
 option(BRPC_DOWNLOAD_GTEST "Download and build a fresh copy of googletest. Requires Internet access." OFF)
 set(BRPC_SYSTEM_GTEST_SOURCE_DIR "" CACHE PATH "System googletest source directory.")
@@ -151,26 +161,28 @@ list(REMOVE_ITEM BVAR_SOURCES ${CMAKE_SOURCE_DIR}/src/bvar/default_variables.cpp
 
 file(GLOB TEST_BVAR_SRCS "bvar_*_unittest.cpp")
 add_executable(test_bvar $<TARGET_OBJECTS:BUTIL_LIB>
+                         $<TARGET_OBJECTS:PROTO_LIB>
                          ${BVAR_SOURCES}
                          ${TEST_BVAR_SRCS})
 target_link_libraries(test_bvar gtest
                                 ${GPERFTOOLS_LIBRARIES}
                                 ${DYNAMIC_LIB})
 
-add_library(TEST_PROTO_OBJ OBJECT ${TEST_PROTO_SRCS})
 add_executable(test_butil ${TEST_BUTIL_SOURCES}
-                          $<TARGET_OBJECTS:TEST_PROTO_OBJ>
+                          $<TARGET_OBJECTS:TEST_PROTO_LIB>
                           $<TARGET_OBJECTS:BUTIL_LIB>
-                          $<TARGET_OBJECTS:OBJ_LIB>)
+                          $<TARGET_OBJECTS:OBJ_LIB>
+                          $<TARGET_OBJECTS:PROTO_LIB>)
 target_link_libraries(test_butil gtest ${GPERFTOOLS_LIBRARIES} ${DYNAMIC_LIB})
 
 file(GLOB BTHREAD_UNITTESTS "bthread*unittest.cpp")
 foreach(BTHREAD_UT ${BTHREAD_UNITTESTS})
     get_filename_component(BTHREAD_UT_WE ${BTHREAD_UT} NAME_WE)
     add_executable(${BTHREAD_UT_WE} ${BTHREAD_UT} 
-                                    $<TARGET_OBJECTS:TEST_PROTO_OBJ>
+                                    $<TARGET_OBJECTS:TEST_PROTO_LIB>
                                     $<TARGET_OBJECTS:BUTIL_LIB>
-                                    $<TARGET_OBJECTS:OBJ_LIB>)
+                                    $<TARGET_OBJECTS:OBJ_LIB>
+                                    $<TARGET_OBJECTS:PROTO_LIB>)
     target_link_libraries(${BTHREAD_UT_WE}
                           gtest_main
                           ${GPERFTOOLS_LIBRARIES}
@@ -181,9 +193,10 @@ file(GLOB BRPC_UNITTESTS "brpc_*_unittest.cpp")
 foreach(BRPC_UT ${BRPC_UNITTESTS})
     get_filename_component(BRPC_UT_WE ${BRPC_UT} NAME_WE)
     add_executable(${BRPC_UT_WE} ${BRPC_UT}
-                                 $<TARGET_OBJECTS:TEST_PROTO_OBJ>
+                                 $<TARGET_OBJECTS:TEST_PROTO_LIB>
                                  $<TARGET_OBJECTS:BUTIL_LIB>
-                                 $<TARGET_OBJECTS:OBJ_LIB>)
+                                 $<TARGET_OBJECTS:OBJ_LIB>
+                                 $<TARGET_OBJECTS:PROTO_LIB>)
     target_link_libraries(${BRPC_UT_WE}
                           gtest_main
                           ${GPERFTOOLS_LIBRARIES}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ compile_proto(PROTO_HDRS PROTO_SRCS ${CMAKE_BINARY_DIR}/test
                                     "${TEST_PROTO_FILES}")
 add_library(TEST_PROTO_LIB OBJECT ${PROTO_SRCS} ${PROTO_HDRS})
 
-option(BRPC_DOWNLOAD_GTEST "Download and build a fresh copy of googletest. Requires Internet access." OFF)
+option(BRPC_DOWNLOAD_GTEST "Download and build a fresh copy of googletest. Requires Internet access." ON)
 set(BRPC_SYSTEM_GTEST_SOURCE_DIR "" CACHE PATH "System googletest source directory.")
 
 if(BRPC_DOWNLOAD_GTEST)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,9 +12,16 @@ foreach(PROTO ${PROTOS})
     )
 endforeach()
 
-find_path(GTEST_HEADER NAMES gtest/gtest.h)
-find_library(GTEST_LIB NAMES gtest)
-find_library(GTEST_MAIN_LIB NAMES gtest_main)
+option(BRPC_DOWNLOAD_GTEST "Download and build a fresh copy of googletest. Requires Internet access." OFF)
+set(BRPC_SYSTEM_GTEST_SOURCE_DIR "" CACHE PATH "System googletest source directory.")
+
+if(BRPC_DOWNLOAD_GTEST)
+  include(SetupGtest)
+elseif(BRPC_SYSTEM_GTEST_SOURCE_DIR)
+  add_subdirectory("${BRPC_SYSTEM_GTEST_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/system-googletest-build")
+else()
+  message(FATAL_ERROR "Googletest is not available")
+endif()
 
 set(CMAKE_CPP_FLAGS "-DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DGFLAGS_NS=${GFLAGS_NS}")
 set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES -D__STRICT_ANSI__ -include ${CMAKE_SOURCE_DIR}/test/sstream_workaround.h")
@@ -146,7 +153,7 @@ file(GLOB TEST_BVAR_SRCS "bvar_*_unittest.cpp")
 add_executable(test_bvar $<TARGET_OBJECTS:BUTIL_LIB>
                          ${BVAR_SOURCES}
                          ${TEST_BVAR_SRCS})
-target_link_libraries(test_bvar ${GTEST_LIB}
+target_link_libraries(test_bvar gtest
                                 ${GPERFTOOLS_LIBRARIES}
                                 ${DYNAMIC_LIB})
 
@@ -155,7 +162,7 @@ add_executable(test_butil ${TEST_BUTIL_SOURCES}
                           $<TARGET_OBJECTS:TEST_PROTO_OBJ>
                           $<TARGET_OBJECTS:BUTIL_LIB>
                           $<TARGET_OBJECTS:OBJ_LIB>)
-target_link_libraries(test_butil ${GTEST_LIB} ${GPERFTOOLS_LIBRARIES} ${DYNAMIC_LIB})
+target_link_libraries(test_butil gtest ${GPERFTOOLS_LIBRARIES} ${DYNAMIC_LIB})
 
 file(GLOB BTHREAD_UNITTESTS "bthread*unittest.cpp")
 foreach(BTHREAD_UT ${BTHREAD_UNITTESTS})
@@ -165,8 +172,7 @@ foreach(BTHREAD_UT ${BTHREAD_UNITTESTS})
                                     $<TARGET_OBJECTS:BUTIL_LIB>
                                     $<TARGET_OBJECTS:OBJ_LIB>)
     target_link_libraries(${BTHREAD_UT_WE}
-                          ${GTEST_MAIN_LIB}
-                          ${GTEST_LIB}
+                          gtest_main
                           ${GPERFTOOLS_LIBRARIES}
                           ${DYNAMIC_LIB})
 endforeach()
@@ -179,7 +185,7 @@ foreach(BRPC_UT ${BRPC_UNITTESTS})
                                  $<TARGET_OBJECTS:BUTIL_LIB>
                                  $<TARGET_OBJECTS:OBJ_LIB>)
     target_link_libraries(${BRPC_UT_WE}
-                          ${GTEST_MAIN_LIB}
+                          gtest_main
                           ${GPERFTOOLS_LIBRARIES}
                           ${GTEST_LIB}
                           ${DYNAMIC_LIB})


### PR DESCRIPTION
Improve cmake by:

- Use GNUInstallDirs to determine install directories for better compatibility
- Compile gtest as a subproject which is recommended by gtest team, instead of depending on a pre-built one.
- Add a build option to clone and compile gtest automatically
- Add a cache variable to specify a system-wide gtest source dir for those who do not want to clone
- Generate and install a pkg-config file `brpc.pc` to make depending on brpc easier with build systems that respect the xNIX-standard way (i.e. anything significant except bazel).
- Incorporate protos into cmake dependency system and compile protos at build time. Reconfiguration  no longer recompiles protos and will no longer trigger a huge recompilation.