### PR TITLE
Fix mac build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ MCPACK2PB_OBJS = src/idl_options.pb.o $(addsuffix .o, $(basename $(MCPACK2PB_SOU
 
 ifeq (ENABLE_THRIFT_FRAMED_PROTOCOL, $(findstring ENABLE_THRIFT_FRAMED_PROTOCOL, $(CPPFLAGS)))
     THRIFT_OBJS = $(addsuffix .o, $(basename $(THRIFT_SOURCES)))
+    libbrpc_thrift = $(libbrpc_thrift.a)
 endif
 
 OBJS=$(BUTIL_OBJS) $(BVAR_OBJS) $(BTHREAD_OBJS) $(JSON2PB_OBJS) $(MCPACK2PB_OBJS) $(BRPC_OBJS)
@@ -203,7 +204,7 @@ DEBUG_OBJS = $(OBJS:.o=.dbg.o)
 PROTOS=$(BRPC_PROTOS) src/idl_options.proto
 
 .PHONY:all
-all:  protoc-gen-mcpack libbrpc.a $(TARGET_LIB_DY) libbrpc_thrift.a  output/include output/lib output/bin
+all:  protoc-gen-mcpack libbrpc.a $(TARGET_LIB_DY) $(libbrpc_thrift) output/include output/lib output/bin
 
 .PHONY:debug
 debug: test/libbrpc.dbg.a test/libbvar.dbg.a
@@ -211,7 +212,7 @@ debug: test/libbrpc.dbg.a test/libbvar.dbg.a
 .PHONY:clean
 clean:
 	@echo "Cleaning"
-	@rm -rf src/mcpack2pb/generator.o protoc-gen-mcpack libbrpc.a $(TARGET_LIB_DY) libbrpc_thrift.a $(OBJS) output/include output/lib output/bin $(PROTOS:.proto=.pb.h) $(PROTOS:.proto=.pb.cc)
+	@rm -rf src/mcpack2pb/generator.o protoc-gen-mcpack libbrpc.a $(TARGET_LIB_DY) $(libbrpc_thrift) $(OBJS) output/include output/lib output/bin $(PROTOS:.proto=.pb.h) $(PROTOS:.proto=.pb.cc)
 
 .PHONY:clean_debug
 clean_debug:
@@ -248,9 +249,11 @@ test/libbrpc.dbg.a:$(BRPC_PROTOS:.proto=.pb.h) $(DEBUG_OBJS)
 	@echo "Packing $@"
 	@ar crs $@ $(filter %.o,$^)
 
+ifeq (ENABLE_THRIFT_FRAMED_PROTOCOL, $(findstring ENABLE_THRIFT_FRAMED_PROTOCOL, $(CPPFLAGS)))
 libbrpc_thrift.a:$(THRIFT_OBJS)
 	@echo "Packing $@"
 	@ar crs $@ $(filter %.o,$^)
+endif
 
 .PHONY:output/include
 output/include:
@@ -260,7 +263,7 @@ output/include:
 	@cp src/idl_options.proto src/idl_options.pb.h $@
 
 .PHONY:output/lib
-output/lib:libbrpc.a $(TARGET_LIB_DY) libbrpc_thrift.a
+output/lib:libbrpc.a $(TARGET_LIB_DY) $(libbrpc_thrift)
 	@echo "Copying to $@"
 	@mkdir -p $@
 	@cp $^ $@

--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -272,7 +272,7 @@ if [ ! -z "$DEBUGSYMBOLS" ]; then
 fi
 if [ "$SYSTEM" = "Darwin" ]; then
     CPPFLAGS="${CPPFLAGS} -Wno-deprecated-declarations"
-    version=`system_profiler SPSoftwareDataType | grep "System Version" | awk '{print $5}' | awk -F. '{printf "%d.%d", $1, $2}'`
+    version="$(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}')"
     if [[ `echo "$version<10.12" | bc -l` == 1 ]]; then
         CPPFLAGS="${CPPFLAGS} -DNO_CLOCK_GETTIME_IN_MAC"
     fi

--- a/src/brpc/global.cpp
+++ b/src/brpc/global.cpp
@@ -467,10 +467,11 @@ static void GlobalInitializeOrDieImpl() {
     }
 
     // Register Thrift framed protocol if linked
-
+#ifdef ENABLE_THRIFT_FRAMED_PROTOCOL
     if (brpc::RegisterThriftProtocol) {
         brpc::RegisterThriftProtocol();
     }
+#endif
 
     // Only valid at client side
     Protocol ubrpc_compack_protocol = {


### PR DESCRIPTION
1. Fix can't get correct mac version on latest mac OSX, use a common script to do that.
2. Fix build error when disable thrift support. Without --with-thrift parameter, the libbrpc_thrift.a should not be depends on. 