### PR TITLE
Fix OpenSSL search and librt problems on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,14 @@ if(NOT PROTOC_LIB)
     message(FATAL_ERROR "Fail to find protoc lib")
 endif()
 
-find_path(SSL_INCLUDE_PATH NAMES openssl/ssl.h)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(OPENSSL_ROOT_DIR
+        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
+        )
+endif()
+
+include(FindOpenSSL)
+set(SSL_INCLUDE_PATH ${OPENSSL_INCLUDE_DIR})
 find_library(SSL_LIB NAMES ssl)
 if ((NOT SSL_INCLUDE_PATH) OR (NOT SSL_LIB))
     message(FATAL_ERROR "Fail to find ssl")
@@ -163,7 +170,18 @@ set(DYNAMIC_LIB
     dl
     z
     )
-set(BRPC_PRIVATE_LIBS "-lgflags -lprotobuf -lleveldb -lprotoc -lrt -lssl -lcrypto -ldl -lz")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(BRPC_PRIVATE_LIBS "-lgflags -lprotobuf -lleveldb -lprotoc -lrt -lssl -lcrypto -ldl -lz")
+
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(BRPC_PRIVATE_LIBS "-lgflags -lprotobuf -lleveldb -lprotoc -lssl -lcrypto -ldl -lz")
+
+else()
+    set(BRPC_PRIVATE_LIBS "-lgflags -lprotobuf -lleveldb -lprotoc -lrt -lssl -lcrypto -ldl -lz")
+
+endif()
+
 if(BRPC_WITH_GLOG)
     set(DYNAMIC_LIB ${DYNAMIC_LIB} ${GLOG_LIB})
     set(BRPC_PRIVATE_LIBS "${BRPC_PRIVATE_LIBS} -lglog")


### PR DESCRIPTION
I have tried to compile brpc on my MacBook, but where are some platform compatibility problems in CMakeLists.txt.

OpenSSL on macOS is protected by sysytem and can not be upgraded, and usually most developer use Homebrew installed OpenSSL instead. I try use cmake built-in module `FindOpenSSL` to find include and library of OpenSSL, and set previous used variables correctly.

Another problem is that, librt is not existed on macOS and I add a branch to decide linker parameters by OS type. Some people on stackoverflow said that it is unnecessary to use `-lrt` on Linux. I keep it on Linux branch, for there is no test cases to run and test its compatibility and whether it runs correctly, though I can build it without `-lrt` on debian successfully.

With this fix, cmake can be used to build brpc on macOS.