### PR TITLE
Circuit breaker

### DIFF
--- a/src/brpc/channel.cpp
+++ b/src/brpc/channel.cpp
@@ -44,6 +44,7 @@ ChannelOptions::ChannelOptions()
     , timeout_ms(500)
     , backup_request_ms(-1)
     , max_retry(3)
+    , enable_circuit_breaker(false)
     , protocol(PROTOCOL_BAIDU_STD)
     , connection_type(CONNECTION_TYPE_UNKNOWN)
     , succeed_without_server(true)
@@ -383,6 +384,7 @@ void Channel::CallMethod(const google::protobuf::MethodDescriptor* method,
     cntl->_request_protocol = _options.protocol;
     cntl->_preferred_index = _preferred_index;
     cntl->_retry_policy = _options.retry_policy;
+    cntl->_enable_circuit_breaker = _options.enable_circuit_breaker;
     const CallId correlation_id = cntl->call_id();
     const int rc = bthread_id_lock_and_reset_range(
                     correlation_id, NULL, 2 + cntl->max_retry());

--- a/src/brpc/channel.cpp
+++ b/src/brpc/channel.cpp
@@ -384,7 +384,9 @@ void Channel::CallMethod(const google::protobuf::MethodDescriptor* method,
     cntl->_request_protocol = _options.protocol;
     cntl->_preferred_index = _preferred_index;
     cntl->_retry_policy = _options.retry_policy;
-    cntl->_enable_circuit_breaker = _options.enable_circuit_breaker;
+    if (_options.enable_circuit_breaker) {
+        cntl->add_flag(Controller::FLAGS_ENABLED_CIRCUIT_BREAKER);
+    }
     const CallId correlation_id = cntl->call_id();
     const int rc = bthread_id_lock_and_reset_range(
                     correlation_id, NULL, 2 + cntl->max_retry());

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -69,9 +69,9 @@ struct ChannelOptions {
     // Maximum: INT_MAX
     int max_retry;
     
-    // When the error rate of an endpoint is too high, deactivate the node. 
-    // Note that this deactive is GLOBAL, and the endpoint will become 
-    // unavailable for the next period of time after the deactive.
+    // When the error rate of a server node is too high, isolate the node. 
+    // Note that this isolation is GLOBAL, the node will become unavailable 
+    // for all channels running in this process during the isolation.
     // Default: false
     bool enable_circuit_breaker;
 

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -69,6 +69,12 @@ struct ChannelOptions {
     // Maximum: INT_MAX
     int max_retry;
     
+    // When the error rate of an endpoint is too high, deactivate the node. 
+    // Note that this deactive is GLOBAL, and the endpoint will become 
+    // unavailable for the next period of time after the deactive.
+    // Default: false
+    bool enable_circuit_breaker;
+
     // Serialization protocol, defined in src/brpc/options.proto
     // NOTE: You can assign name of the protocol to this field as well, for
     // Example: options.protocol = "baidu_std";

--- a/src/brpc/circuit_breaker.cpp
+++ b/src/brpc/circuit_breaker.cpp
@@ -20,18 +20,18 @@
 
 namespace brpc {
 
-DEFINE_int32(circuit_breaker_short_window_size, 400,
+DEFINE_int32(circuit_breaker_short_window_size, 500,
     "Short window sample size.");
 DEFINE_int32(circuit_breaker_long_window_size, 1000,
     "Long window sample size.");
 DEFINE_int32(circuit_breaker_short_window_error_percent, 10,
     "The maximum error rate allowed by the short window, ranging from 0-99.");
-DEFINE_int32(circuit_breaker_long_window_error_percent, 30, 
+DEFINE_int32(circuit_breaker_long_window_error_percent, 5, 
     "The maximum error rate allowed by the long window, ranging from 0-99.");
 DEFINE_int32(circuit_breaker_min_error_cost_us, 500,
     "The minimum error_cost, when the ema of error cost is less than this "
     "value, it will be set to zero.");
-DEFINE_int32(circuit_breaker_max_failed_latency_mutilple, 3,
+DEFINE_int32(circuit_breaker_max_failed_latency_mutilple, 2,
     "The maximum multiple of the latency of the failed request relative to "
     "the average latency of the success requests.");
 

--- a/src/brpc/circuit_breaker.cpp
+++ b/src/brpc/circuit_breaker.cpp
@@ -152,8 +152,7 @@ CircuitBreaker::CircuitBreaker()
 }
 
 bool CircuitBreaker::OnCallEnd(int error_code, int64_t latency) {
-    bool broken = _broken.load(butil::memory_order_relaxed);
-    if (broken) {
+    if (_broken.load(butil::memory_order_relaxed)) {
         return false;
     } 
     if (!_long_window.OnCallEnd(error_code, latency) ||

--- a/src/brpc/circuit_breaker.cpp
+++ b/src/brpc/circuit_breaker.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <gflags/gflags.h>
 #include <butil/time.h>
+#include <butil/logging.h>
 #include "brpc/circuit_breaker.h"
 
 namespace brpc {
@@ -116,7 +117,9 @@ int64_t CircuitBreaker::EmaErrorRecorder::UpdateLatency(int64_t latency) {
 bool CircuitBreaker::EmaErrorRecorder::UpdateErrorCost(int64_t error_cost, 
                                                        int64_t ema_latency) {
     const int max_mutilple = FLAGS_circuit_breaker_max_failed_latency_mutilple;
-    error_cost = std::min(ema_latency * max_mutilple, error_cost);
+    if (ema_latency != 0) {
+        error_cost = std::min(ema_latency * max_mutilple, error_cost);
+    }
     //Errorous response
     if (error_cost != 0) {
         int64_t ema_error_cost = 

--- a/src/brpc/circuit_breaker.cpp
+++ b/src/brpc/circuit_breaker.cpp
@@ -1,0 +1,186 @@
+// Copyright (c) 2014 Baidu, Inc.G
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Lei He (helei@qiyi.com)
+
+#include <cmath>
+#include <gflags/gflags.h>
+#include "brpc/circuit_breaker.h"
+
+namespace brpc {
+
+DEFINE_int32(circuit_breaker_short_window_size, 30,
+    "Short window sample size.");
+DEFINE_int32(circuit_breaker_long_window_size, 100,
+    "Long window sample size.");
+DEFINE_int32(circuit_breaker_short_window_error_percent, 5,
+    "The maximum error rate allowed by the short window, ranging from 0-99.");
+DEFINE_int32(circuit_breaker_long_window_error_percent, 3, 
+    "The maximum error rate allowed by the long window, ranging from 0-99.");
+DEFINE_int32(circuit_breaker_min_error_cost_us, 100,
+    "The minimum error_cost, when the ema of error cost is less than this "
+    "value, it will be set to zero.");
+
+namespace {
+// EPSILON is used to generate the smoothing coefficient when calculating EMA.
+// The larger the EPSILON, the larger the smoothing coefficient, which means 
+// that the proportion of early data is larger.
+// smooth = pow(EPSILON, 1 / window_size), 
+// eg: when window_size = 100,
+// EPSILON = 0.1, smooth = 0.9772
+// EPSILON = 0.3, smooth = 0.9880
+// when window_size = 30,
+// EPSILON = 0.1, smooth = 0.9261
+// EPSILON = 0.3, smooth = 0.9606
+const double EPSILON = 0.1;
+}  // namepace
+
+CircuitBreaker::EmaErrorRecorder::EmaErrorRecorder(int window_size, 
+                                                   int max_error_percent)
+    : _window_size(window_size)
+    , _max_error_percent(max_error_percent)
+    , _smooth(std::pow(EPSILON, 1.0/window_size))
+    , _init_completed(false)
+    , _sample_count(0)
+    , _ema_error_cost(0)
+    , _ema_latency(0) 
+    , _broken(false) {
+}
+
+bool CircuitBreaker::EmaErrorRecorder::OnCallEnd(int error_code, 
+                                                 int64_t latency) {
+    if (_broken.load(butil::memory_order_relaxed)) {
+        return false;
+    }
+
+    int64_t ema_latency = 0;
+    bool healthy = false;
+    if (error_code == 0) {
+        ema_latency = UpdateLatency(latency);
+        healthy = UpdateErrorCost(0, ema_latency);
+    } else {
+        ema_latency = _ema_latency.load(butil::memory_order_relaxed);
+        healthy = UpdateErrorCost(latency, ema_latency);
+    }
+
+    int sample_count = _sample_count.fetch_add(1, butil::memory_order_relaxed);
+    bool init_completed = _init_completed.load(butil::memory_order_acquire);
+    if (!init_completed && sample_count >= _window_size) {
+        _init_completed.store(true, butil::memory_order_release);
+        init_completed = true;
+    }
+    
+    if (!init_completed) {
+        return true;
+    }
+    if (!healthy) {
+        _broken.store(true, butil::memory_order_relaxed);
+    }
+    return healthy;
+}
+
+int64_t CircuitBreaker::EmaErrorRecorder::UpdateLatency(int64_t latency) {
+    while (true) {
+        int64_t ema_latency = _ema_latency.load(butil::memory_order_relaxed);
+        int64_t next_ema_latency = 0;
+        if (0 == ema_latency) {
+            next_ema_latency = latency;
+        } else {
+            next_ema_latency = ema_latency * _smooth + latency * (1 - _smooth);
+        }
+        if (_ema_latency.compare_exchange_weak(ema_latency, next_ema_latency)) {
+            return next_ema_latency;
+        }
+    }
+}
+
+bool CircuitBreaker::EmaErrorRecorder::UpdateErrorCost(int64_t error_cost, 
+                                                       int64_t ema_latency) {
+    //Errorous response
+    if (error_cost != 0) {
+        int64_t ema_error_cost = 
+            _ema_error_cost.fetch_add(error_cost, butil::memory_order_relaxed);
+        ema_error_cost += error_cost; 
+        int64_t max_error_cost = ema_latency * _window_size * 
+            (_max_error_percent / 100.0) * (1.0 + EPSILON);
+        return ema_error_cost <= max_error_cost;
+    }
+
+    //Ordinary response
+    while (true) {
+        int64_t ema_error_cost = 
+            _ema_error_cost.load(butil::memory_order_relaxed);
+        if (ema_error_cost == 0) {
+            break;
+        } else if (ema_error_cost < FLAGS_circuit_breaker_min_error_cost_us) {
+            if (_ema_error_cost.compare_exchange_weak(
+                ema_error_cost, 0, butil::memory_order_relaxed)) {
+                break;
+            }
+        } else {
+            int64_t next_ema_error_cost = ema_error_cost * _smooth;
+            if (_ema_error_cost.compare_exchange_weak(
+                ema_error_cost, next_ema_error_cost)) {
+                break;
+            }
+        }
+    }
+    return true;
+}
+
+void CircuitBreaker::EmaErrorRecorder::Reset() {
+    _init_completed.store(false, butil::memory_order_relaxed);
+    _sample_count.store(0, butil::memory_order_relaxed);
+    _ema_error_cost.store(0, butil::memory_order_relaxed);
+    _ema_latency.store(0, butil::memory_order_relaxed);
+    _broken.store(false, butil::memory_order_relaxed);
+}
+
+CircuitBreaker::CircuitBreaker() {
+    auto short_recorder_adder = 
+        std::bind(&CircuitBreaker::AddErrorRecorder, 
+                  std::placeholders::_1, 
+                  FLAGS_circuit_breaker_short_window_size,
+                  FLAGS_circuit_breaker_short_window_error_percent);
+    auto long_recorder_adder = 
+        std::bind(&CircuitBreaker::AddErrorRecorder,
+                  std::placeholders::_1,
+                  FLAGS_circuit_breaker_long_window_size,
+                  FLAGS_circuit_breaker_long_window_error_percent);
+    _recorders.Modify(short_recorder_adder);
+    _recorders.Modify(long_recorder_adder);
+}
+
+void CircuitBreaker::Reset() {
+    auto recorder_reseter = std::bind(&CircuitBreaker::ResetEmaRecorders,
+                                      std::placeholders::_1);
+    _recorders.Modify(recorder_reseter);
+}
+
+bool CircuitBreaker::OnCallEnd(int error_code, int64_t latency) {
+    butil::DoublyBufferedData<ErrRecorderList>::ScopedPtr p;
+    if (0 == _recorders.Read(&p)) {
+        for (auto& recorder : (*p)) {
+            if (!recorder->OnCallEnd(error_code, latency)) {
+                return false;
+            }
+        }
+        return true;
+    } else {
+        LOG(WARNING) << "EmaErrorRecorder no data";
+        return true;
+    }
+}
+
+}  // namespace brpc

--- a/src/brpc/circuit_breaker.cpp
+++ b/src/brpc/circuit_breaker.cpp
@@ -20,9 +20,9 @@
 
 namespace brpc {
 
-DEFINE_int32(circuit_breaker_short_window_size, 30,
+DEFINE_int32(circuit_breaker_short_window_size, 100,
     "Short window sample size.");
-DEFINE_int32(circuit_breaker_long_window_size, 100,
+DEFINE_int32(circuit_breaker_long_window_size, 1000,
     "Long window sample size.");
 DEFINE_int32(circuit_breaker_short_window_error_percent, 5,
     "The maximum error rate allowed by the short window, ranging from 0-99.");

--- a/src/brpc/circuit_breaker.cpp
+++ b/src/brpc/circuit_breaker.cpp
@@ -17,7 +17,6 @@
 #include <cmath>
 #include <gflags/gflags.h>
 #include <butil/time.h>
-#include <butil/logging.h>
 #include "brpc/circuit_breaker.h"
 
 namespace brpc {

--- a/src/brpc/circuit_breaker.cpp
+++ b/src/brpc/circuit_breaker.cpp
@@ -32,12 +32,12 @@ DEFINE_int32(circuit_breaker_long_window_error_percent, 5,
 DEFINE_int32(circuit_breaker_min_error_cost_us, 500,
     "The minimum error_cost, when the ema of error cost is less than this "
     "value, it will be set to zero.");
-DEFINE_int32(circuit_breaker_max_failed_latency_mutilple, 2,
+DEFINE_int32(circuit_breaker_max_failed_latency_mutiple, 2,
     "The maximum multiple of the latency of the failed request relative to "
     "the average latency of the success requests.");
 DEFINE_int32(circuit_breaker_min_isolation_duration_ms, 100,
     "Minimum isolation duration in milliseconds");
-DEFINE_int32(circuit_breaker_max_isolation_duration_ms, 300000,
+DEFINE_int32(circuit_breaker_max_isolation_duration_ms, 30000,
     "Maximum isolation duration in milliseconds");
 
 namespace {
@@ -115,9 +115,9 @@ int64_t CircuitBreaker::EmaErrorRecorder::UpdateLatency(int64_t latency) {
 
 bool CircuitBreaker::EmaErrorRecorder::UpdateErrorCost(int64_t error_cost, 
                                                        int64_t ema_latency) {
-    const int max_mutilple = FLAGS_circuit_breaker_max_failed_latency_mutilple;
+    const int max_mutiple = FLAGS_circuit_breaker_max_failed_latency_mutiple;
     if (ema_latency != 0) {
-        error_cost = std::min(ema_latency * max_mutilple, error_cost);
+        error_cost = std::min(ema_latency * max_mutiple, error_cost);
     }
     //Errorous response
     if (error_cost != 0) {
@@ -187,9 +187,8 @@ void CircuitBreaker::UpdateIsolationDuration() {
         const int min_isolation_duration_ms = 
             FLAGS_circuit_breaker_min_isolation_duration_ms;
         if (now_time_ms - _last_reset_time_ms < max_isolation_duration_ms) {
-            isolation_duration_ms *= 2;
             isolation_duration_ms = 
-                std::min(isolation_duration_ms, max_isolation_duration_ms);
+                std::min(isolation_duration_ms * 2, max_isolation_duration_ms);
         } else {
             isolation_duration_ms = min_isolation_duration_ms;
         }

--- a/src/brpc/circuit_breaker.cpp
+++ b/src/brpc/circuit_breaker.cpp
@@ -20,18 +20,18 @@
 
 namespace brpc {
 
-DEFINE_int32(circuit_breaker_short_window_size, 100,
+DEFINE_int32(circuit_breaker_short_window_size, 400,
     "Short window sample size.");
 DEFINE_int32(circuit_breaker_long_window_size, 1000,
     "Long window sample size.");
-DEFINE_int32(circuit_breaker_short_window_error_percent, 5,
+DEFINE_int32(circuit_breaker_short_window_error_percent, 10,
     "The maximum error rate allowed by the short window, ranging from 0-99.");
-DEFINE_int32(circuit_breaker_long_window_error_percent, 3, 
+DEFINE_int32(circuit_breaker_long_window_error_percent, 30, 
     "The maximum error rate allowed by the long window, ranging from 0-99.");
-DEFINE_int32(circuit_breaker_min_error_cost_us, 100,
+DEFINE_int32(circuit_breaker_min_error_cost_us, 500,
     "The minimum error_cost, when the ema of error cost is less than this "
     "value, it will be set to zero.");
-DEFINE_int32(circuit_breaker_max_failed_latency_mutilple, 2,
+DEFINE_int32(circuit_breaker_max_failed_latency_mutilple, 3,
     "The maximum multiple of the latency of the failed request relative to "
     "the average latency of the success requests.");
 

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2014 Baidu, Inc.G
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Lei He (helei@qiyi.com)
+
+#ifndef BRPC_CIRCUIT_BREAKER_H
+#define BRPC_CIRCUIT_BREAKER_H
+                                            
+#include "butil/containers/doubly_buffered_data.h"
+#include "butil/atomicops.h"
+
+namespace brpc {
+
+class CircuitBreaker {
+public:
+    CircuitBreaker();
+
+    ~CircuitBreaker() {}
+
+    // Sampling the current rpc. Returns false if the endpoint needs to 
+    // be deactivated. Otherwise return true.
+    // error_code: Error_code of this call, 0 means success.
+    // latency: Time cost of this call.
+    // Note: Once OnCallEnd() determines that a node needs to be deactivated,
+    // it will always return false until you call Reset(). Usually Reset() 
+    // will be called in the health check thread.
+    bool OnCallEnd(int error_code, int64_t latency);
+
+    // Reset circuit breaker, will erase the historical data and start 
+    // sampling again.
+    // This method is thread safe, and it is inefficient, you better 
+    // call it only when you need.
+    void Reset();
+
+private:
+    class EmaErrorRecorder {
+    public:
+        EmaErrorRecorder(int windows_size,  int max_error_percent);
+        bool OnCallEnd(int error_code, int64_t latency);
+        void Reset();
+     
+    private:
+        int64_t UpdateLatency(int64_t latency);
+        bool UpdateErrorCost(int64_t latency, int64_t ema_latency);
+        void OnStarting(int error_code, int64_t latency);
+
+        const int _window_size;
+        const int _max_error_percent;
+        const double _smooth;
+        butil::atomic<bool> _init_completed;
+        butil::atomic<int>  _sample_count;
+        butil::atomic<int64_t> _ema_error_cost;
+        butil::atomic<int64_t> _ema_latency;
+        butil::atomic<bool> _broken;
+    };
+    typedef std::vector<std::unique_ptr<EmaErrorRecorder>> ErrRecorderList;
+
+    static bool ResetEmaRecorders(ErrRecorderList& recorders) {
+        for (auto& recorder : recorders) {
+            recorder->Reset();
+        }
+        return true;
+    }
+    
+    static bool AddErrorRecorder(ErrRecorderList& recorders,
+                                 int window_size, int max_error_percent){
+        recorders.emplace_back(
+            new EmaErrorRecorder(window_size, max_error_percent));
+        return true;
+    }
+
+    butil::DoublyBufferedData<ErrRecorderList> _recorders;
+};
+
+}  // namespace brpc
+
+#endif // BRPC_CIRCUIT_BREAKER_H_

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -17,7 +17,6 @@
 #ifndef BRPC_CIRCUIT_BREAKER_H
 #define BRPC_CIRCUIT_BREAKER_H
                                             
-#include "butil/containers/doubly_buffered_data.h"
 #include "butil/atomicops.h"
 
 namespace brpc {

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -54,8 +54,8 @@ private:
         const int _window_size;
         const int _max_error_percent;
         const double _smooth;
-        butil::atomic<bool> _init_completed;
-        butil::atomic<int>  _sample_count;
+
+        butil::atomic<int64_t> BAIDU_CACHELINE_ALIGNMENT _sample_count;
         butil::atomic<int64_t> _ema_error_cost;
         butil::atomic<int64_t> _ema_latency;
         butil::atomic<bool> _broken;

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -64,7 +64,7 @@ private:
         const int _max_error_percent;
         const double _smooth;
 
-        butil::atomic<int64_t> BAIDU_CACHELINE_ALIGNMENT _sample_count;
+        butil::atomic<int64_t> _sample_count;
         butil::atomic<int64_t> _ema_error_cost;
         butil::atomic<int64_t> _ema_latency;
     };

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -40,7 +40,16 @@ public:
     // data and start sampling again. Before you call this method, you need to
     // ensure that no one else is calling OnCallEnd.
     void Reset();
+
+    // The duration that should be isolated when the socket fails in milliseconds.
+    // The higher the frequency of socket errors, the longer the duration.
+    int isolation_duration_ms() {
+        return _isolation_duration_ms.load(butil::memory_order_relaxed);
+    }
+
 private:
+    void UpdateIsolationDuration();
+
     class EmaErrorRecorder {
     public:
         EmaErrorRecorder(int windows_size,  int max_error_percent);
@@ -63,6 +72,9 @@ private:
 
     EmaErrorRecorder _long_window;
     EmaErrorRecorder _short_window;
+    int64_t _last_reset_time_ms; 
+    butil::atomic<bool> _broken;
+    butil::atomic<int> _isolation_duration_ms;
 };
 
 }  // namespace brpc

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -67,7 +67,6 @@ private:
         butil::atomic<int64_t> BAIDU_CACHELINE_ALIGNMENT _sample_count;
         butil::atomic<int64_t> _ema_error_cost;
         butil::atomic<int64_t> _ema_latency;
-        butil::atomic<bool> _broken;
     };
 
     EmaErrorRecorder _long_window;

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -277,6 +277,7 @@ Controller::Call::~Call() {
 void Controller::Call::Reset() {
     nretry = 0;
     need_feedback = false;
+    enable_circuit_breaker = false;
     touched_by_stream_creator = false;
     peer_id = (SocketId)-1;
     begin_time_us = 0;

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -765,7 +765,7 @@ void Controller::Call::OnComplete(Controller* c, int error_code/*note*/,
             sending_sock.get(), c, error_code);
     }
     if (enable_circuit_breaker) {
-        if (sending_sock) {
+        if (!sending_sock) {
             SocketUniquePtr sock; 
             if (Socket::Address(peer_id, &sock) == 0) {
                 sock->FeedbackCircuitBreaker(error_code, 

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -778,8 +778,8 @@ void Controller::Call::OnComplete(Controller* c, int error_code/*note*/,
     if (enable_circuit_breaker) {
         SocketUniquePtr sock;
         if (Socket::Address(peer_id, &sock) == 0) {
-//            sock->GetSharedPart()->circuit_breaker.OnCallEnd(
-//                error_code, butil::gettimeofday_us() - begin_time_us);
+            sock->FeedbackCircuitBreaker(error_code, 
+                butil::gettimeofday_us() - begin_time_us);
         }
     }
 }

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -765,9 +765,14 @@ void Controller::Call::OnComplete(Controller* c, int error_code/*note*/,
             sending_sock.get(), c, error_code);
     }
     if (enable_circuit_breaker) {
-        SocketUniquePtr sock; 
-        if (Socket::Address(peer_id, &sock) == 0) {
-            sock->FeedbackCircuitBreaker(error_code, 
+        if (sending_sock) {
+            SocketUniquePtr sock; 
+            if (Socket::Address(peer_id, &sock) == 0) {
+                sock->FeedbackCircuitBreaker(error_code, 
+                    butil::gettimeofday_us() - begin_time_us);
+            }
+        } else {
+            sending_sock->FeedbackCircuitBreaker(error_code, 
                 butil::gettimeofday_us() - begin_time_us);
         }
     }

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -764,17 +764,9 @@ void Controller::Call::OnComplete(Controller* c, int error_code/*note*/,
         c->stream_creator()->CleanupSocketForStream(
             sending_sock.get(), c, error_code);
     }
-    if (enable_circuit_breaker) {
-        if (!sending_sock) {
-            SocketUniquePtr sock; 
-            if (Socket::Address(peer_id, &sock) == 0) {
-                sock->FeedbackCircuitBreaker(error_code, 
-                    butil::gettimeofday_us() - begin_time_us);
-            }
-        } else {
-            sending_sock->FeedbackCircuitBreaker(error_code, 
-                butil::gettimeofday_us() - begin_time_us);
-        }
+    if (enable_circuit_breaker && sending_sock) {
+        sending_sock->FeedbackCircuitBreaker(error_code, 
+            butil::gettimeofday_us() - begin_time_us);
     }
     // Release the `Socket' we used to send/receive data
     sending_sock.reset(NULL);

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -216,6 +216,7 @@ void Controller::InternalReset(bool in_constructor) {
     _rpc_dump_meta = NULL;
     _request_protocol = PROTOCOL_UNKNOWN;
     _max_retry = UNSET_MAGIC_NUM;
+    _enable_circuit_breaker = false;
     _retry_policy = NULL;
     _correlation_id = INVALID_BTHREAD_ID;
     _connection_type = CONNECTION_TYPE_UNKNOWN;
@@ -258,6 +259,7 @@ void Controller::InternalReset(bool in_constructor) {
 Controller::Call::Call(Controller::Call* rhs)
     : nretry(rhs->nretry)
     , need_feedback(rhs->need_feedback)
+    , enable_circuit_breaker(rhs->enable_circuit_breaker)
     , touched_by_stream_creator(rhs->touched_by_stream_creator)
     , peer_id(rhs->peer_id)
     , begin_time_us(rhs->begin_time_us)
@@ -266,6 +268,7 @@ Controller::Call::Call(Controller::Call* rhs)
     // setting all the fields to next call and _current_call.OnComplete
     // will behave incorrectly.
     rhs->need_feedback = false;
+    rhs->enable_circuit_breaker = false;
     rhs->touched_by_stream_creator = false;
     rhs->peer_id = (SocketId)-1;
 }
@@ -277,6 +280,7 @@ Controller::Call::~Call() {
 void Controller::Call::Reset() {
     nretry = 0;
     need_feedback = false;
+    enable_circuit_breaker = false;
     touched_by_stream_creator = false;
     peer_id = (SocketId)-1;
     begin_time_us = 0;
@@ -771,6 +775,13 @@ void Controller::Call::OnComplete(Controller* c, int error_code/*note*/,
             { begin_time_us, peer_id, error_code, c };
         c->_lb->Feedback(info);
     }
+    if (enable_circuit_breaker) {
+        SocketUniquePtr sock;
+        if (Socket::Address(peer_id, &sock) == 0) {
+            sock->FeedbackCircuitBreaker(
+                error_code, butil::gettimeofday_us() - begin_time_us);
+        }
+    }
 }
 
 void Controller::EndRPC(const CompletionInfo& info) {
@@ -963,6 +974,7 @@ void Controller::IssueRPC(int64_t start_realtime_us) {
 
     // Pick a target server for sending RPC
     _current_call.need_feedback = false;
+    _current_call.enable_circuit_breaker = _enable_circuit_breaker;
     SocketUniquePtr tmp_sock;
     if (SingleServer()) {
         // Don't use _current_call.peer_id which is set to -1 after construction

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -765,8 +765,11 @@ void Controller::Call::OnComplete(Controller* c, int error_code/*note*/,
             sending_sock.get(), c, error_code);
     }
     if (enable_circuit_breaker) {
-        sending_sock->FeedbackCircuitBreaker(error_code, 
-            butil::gettimeofday_us() - begin_time_us);
+        SocketUniquePtr sock; 
+        if (Socket::Address(peer_id, &sock) == 0) {
+            sock->FeedbackCircuitBreaker(error_code, 
+                butil::gettimeofday_us() - begin_time_us);
+        }
     }
     // Release the `Socket' we used to send/receive data
     sending_sock.reset(NULL);

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -778,8 +778,8 @@ void Controller::Call::OnComplete(Controller* c, int error_code/*note*/,
     if (enable_circuit_breaker) {
         SocketUniquePtr sock;
         if (Socket::Address(peer_id, &sock) == 0) {
-            sock->FeedbackCircuitBreaker(
-                error_code, butil::gettimeofday_us() - begin_time_us);
+//            sock->GetSharedPart()->circuit_breaker.OnCallEnd(
+//                error_code, butil::gettimeofday_us() - begin_time_us);
         }
     }
 }

--- a/src/brpc/controller.h
+++ b/src/brpc/controller.h
@@ -559,11 +559,12 @@ private:
         void Reset();
         void OnComplete(Controller* c, int error_code, bool responded);
 
-        int nretry;                // sent in nretry-th retry.
-        bool need_feedback;        // The LB needs feedback.
+        int nretry;                   // sent in nretry-th retry.
+        bool need_feedback;           // The LB needs feedback.
+        bool enable_circuit_breaker;  // The channel enabled circuit_breaker
         bool touched_by_stream_creator;
-        SocketId peer_id;          // main server id
-        int64_t begin_time_us;     // sent real time.
+        SocketId peer_id;            // main server id
+        int64_t begin_time_us;       // sent real time.
         // The actual `Socket' for sending RPC. It's socket id will be
         // exactly the same as `peer_id' if `_connection_type' is
         // CONNECTION_TYPE_SINGLE. Otherwise, it may be a temporary
@@ -621,6 +622,7 @@ private:
     // Some of them are copied from `Channel' which might be destroyed
     // after CallMethod.
     int _max_retry;
+    bool _enable_circuit_breaker;
     const RetryPolicy* _retry_policy;
     // Synchronization object for one RPC call. It remains unchanged even 
     // when retry happens. Synchronous RPC will wait on this id.

--- a/src/brpc/controller.h
+++ b/src/brpc/controller.h
@@ -130,6 +130,7 @@ friend void policy::ProcessThriftRequest(InputMessageBase*);
     static const uint32_t FLAGS_USED_BY_RPC = (1 << 13);
     static const uint32_t FLAGS_REQUEST_WITH_AUTH = (1 << 15);
     static const uint32_t FLAGS_PB_JSONIFY_EMPTY_ARRAY = (1 << 16);
+    static const uint32_t FLAGS_ENABLED_CIRCUIT_BREAKER = (1 << 17);
     
 public:
     Controller();
@@ -601,6 +602,16 @@ private:
     void set_used_by_rpc() { add_flag(FLAGS_USED_BY_RPC); }
     bool is_used_by_rpc() const { return has_flag(FLAGS_USED_BY_RPC); }
 
+<<<<<<< HEAD
+=======
+    // Get sock option. .e.g get vip info through ttm kernel module hook,
+    int GetSockOption(int level, int optname, void* optval, socklen_t* optlen);
+
+    bool has_enabled_circuit_breaker() const { 
+        return has_flag(FLAGS_ENABLED_CIRCUIT_BREAKER); 
+    }
+
+>>>>>>> Replace _enable_circuit_breaker with FALGS_ENABLED_CIRCUIT_BREAKER
 private:
     // NOTE: align and group fields to make Controller as compact as possible.
 
@@ -622,7 +633,6 @@ private:
     // Some of them are copied from `Channel' which might be destroyed
     // after CallMethod.
     int _max_retry;
-    bool _enable_circuit_breaker;
     const RetryPolicy* _retry_policy;
     // Synchronization object for one RPC call. It remains unchanged even 
     // when retry happens. Synchronous RPC will wait on this id.

--- a/src/brpc/controller.h
+++ b/src/brpc/controller.h
@@ -560,12 +560,12 @@ private:
         void Reset();
         void OnComplete(Controller* c, int error_code, bool responded);
 
-        int nretry;                   // sent in nretry-th retry.
-        bool need_feedback;           // The LB needs feedback.
-        bool enable_circuit_breaker;  // The channel enabled circuit_breaker
-        bool touched_by_stream_creator;
-        SocketId peer_id;            // main server id
-        int64_t begin_time_us;       // sent real time.
+        int nretry;                     // sent in nretry-th retry.
+        bool need_feedback;             // The LB needs feedback.
+        bool enable_circuit_breaker;    // The channel enabled circuit_breaker
+        bool touched_by_stream_creator; 
+        SocketId peer_id;               // main server id
+        int64_t begin_time_us;          // sent real time.
         // The actual `Socket' for sending RPC. It's socket id will be
         // exactly the same as `peer_id' if `_connection_type' is
         // CONNECTION_TYPE_SINGLE. Otherwise, it may be a temporary

--- a/src/brpc/controller.h
+++ b/src/brpc/controller.h
@@ -602,16 +602,10 @@ private:
     void set_used_by_rpc() { add_flag(FLAGS_USED_BY_RPC); }
     bool is_used_by_rpc() const { return has_flag(FLAGS_USED_BY_RPC); }
 
-<<<<<<< HEAD
-=======
-    // Get sock option. .e.g get vip info through ttm kernel module hook,
-    int GetSockOption(int level, int optname, void* optval, socklen_t* optlen);
-
     bool has_enabled_circuit_breaker() const { 
         return has_flag(FLAGS_ENABLED_CIRCUIT_BREAKER); 
     }
 
->>>>>>> Replace _enable_circuit_breaker with FALGS_ENABLED_CIRCUIT_BREAKER
 private:
     // NOTE: align and group fields to make Controller as compact as possible.
 

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -36,6 +36,7 @@
 #include "brpc/event_dispatcher.h"          // RemoveConsumer
 #include "brpc/socket.h"
 #include "brpc/describable.h"               // Describable
+#include "brpc/circuit_breaker.h"           // CircuitBreaker
 #include "brpc/input_messenger.h"
 #include "brpc/details/sparse_minute_counter.h"
 #include "brpc/stream_impl.h"
@@ -867,7 +868,7 @@ int Socket::SetFailed(int error_code, const char* error_fmt, ...) {
             // Socket's reference will hit 0(recycle) when no one addresses it.
             ReleaseAdditionalReference();
             // NOTE: This Socket may be recycled at this point, don't
-                // touch anything.
+            // touch anything.
             return 0;
         }
     }

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -42,7 +42,6 @@
 #include "brpc/shared_object.h"
 #include "brpc/policy/rtmp_protocol.h"  // FIXME
 #include "brpc/periodic_task.h"
-#include "brpc/circuit_breaker.h"       // CircuitBreaker
 #if defined(OS_MACOSX)
 #include <sys/event.h>
 #endif
@@ -880,8 +879,8 @@ int Socket::SetFailed() {
 
 void Socket::FeedbackCircuitBreaker(int error_code, int64_t latency_us) {
     if (!GetOrNewSharedPart()->circuit_breaker.OnCallEnd(error_code, latency_us)) {
-        LOG(ERROR) << "Socket[" << *this << "] deactivted by circuit breaker";
-        SetFailed();
+        LOG(ERROR) << "Socket[" << *this << "] isolated by circuit breaker";
+        SetFailed(main_socket_id());
     }
 }
 

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -884,8 +884,7 @@ int Socket::SetFailed() {
 
 void Socket::FeedbackCircuitBreaker(int error_code, int64_t latency_us) {
     if (!GetOrNewSharedPart()->circuit_breaker.OnCallEnd(error_code, latency_us)) {
-        LOG(ERROR) 
-            << "Socket[" << *this << "] deactivted by circuit breaker";
+        LOG(ERROR) << "Socket[" << *this << "] deactivted by circuit breaker";
         SetFailed();
     }
 }

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -737,6 +737,7 @@ int Socket::WaitAndReset(int32_t expected_nref) {
             _pipeline_q->clear();
         }
     }
+    _circuit_breaker.Reset();
     CHECK(NULL == _write_head.load(butil::memory_order_relaxed));
     CHECK_EQ(0, _unwritten_bytes.load(butil::memory_order_relaxed));
     CHECK(!_overcrowded);

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -740,12 +740,6 @@ int Socket::WaitAndReset(int32_t expected_nref) {
             _pipeline_q->clear();
         }
     }
-    
-    SharedPart* sp = GetSharedPart();
-    if (sp) {
-        sp->circuit_breaker.Reset();
-    }
-
     CHECK(NULL == _write_head.load(butil::memory_order_relaxed));
     CHECK_EQ(0, _unwritten_bytes.load(butil::memory_order_relaxed));
     CHECK(!_overcrowded);
@@ -771,6 +765,10 @@ void Socket::Revive() {
                 vref, MakeVRef(id_ver, nref + 1/*note*/),
                 butil::memory_order_release,
                 butil::memory_order_relaxed)) {
+            SharedPart* sp = GetSharedPart();
+            if (sp) {
+                sp->circuit_breaker.Reset();
+            }
             // Set this flag to true since we add additional ref again
             _recycle_flag.store(false, butil::memory_order_relaxed);
             if (_user) {

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -762,8 +762,6 @@ private:
 
     butil::Mutex _stream_mutex;
     std::set<StreamId> *_stream_set;
-
-    CircuitBreaker _circuit_breaker;
 };
 
 } // namespace brpc

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -316,13 +316,7 @@ public:
         __attribute__ ((__format__ (__printf__, 3, 4)));
     static int SetFailed(SocketId id);
 
-    void FeedbackCircuitBreaker(int error_code, int64_t latency_us) {
-        if (!_circuit_breaker.OnCallEnd(error_code, latency_us)) {
-            LOG(ERROR) 
-                << "Socket[" << *this << "] deactivted by circuit breaker";
-            SetFailed();
-        }
-    }
+    void FeedbackCircuitBreaker(int error_code, int64_t latency_us);
 
     bool Failed() const;
 

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -37,7 +37,6 @@
 #include "brpc/options.pb.h"              // ConnectionType
 #include "brpc/socket_id.h"               // SocketId
 #include "brpc/socket_message.h"          // SocketMessagePtr
-#include "brpc/circuit_breaker.h"         // CircuitBreaker
 
 namespace brpc {
 namespace policy {

--- a/test/brpc_naming_service_unittest.cpp
+++ b/test/brpc_naming_service_unittest.cpp
@@ -398,7 +398,7 @@ TEST(NamingServiceTest, consul_with_backup_file) {
                                    restful_map.c_str()));
     ASSERT_EQ(0, server.Start("localhost:8500", NULL));
 
-    bthread_usleep(2000000);
+    bthread_usleep(5000000);
 
     butil::EndPoint n1;
     ASSERT_EQ(0, butil::str2endpoint("10.121.36.189:8003", &n1));


### PR DESCRIPTION
增加了CircuitBreaker：

- 每个Socket中都有一个CircuitBreaker对象
- 在ChannelOptions中新增enable_circuit_breaker开关
- Socket发现CircuitBreaker::OnCallEnd返回false之后调用SetFailed，之后由healthy check thread调用 Reset 来复位。

还存在的问题：
- 只有main socket才需要circuitbreaker，每个socket都有一个circuitbreaker是否有些浪费。
- PR中的默认参数还需要进一步调整。