### PR TITLE
codel concurrency limiter

### DIFF
--- a/src/brpc/concurrency_limiter.h
+++ b/src/brpc/concurrency_limiter.h
@@ -32,7 +32,7 @@ public:
     // false when the concurrency reaches the upper limit, otherwise it 
     // returns true. Normally, when OnRequested returns false, you should 
     // return an ELIMIT error directly.
-    virtual bool OnRequested(int current_concurrency) = 0;
+    virtual bool OnRequested(int current_concurrency, int64_t waiting_us) = 0;
 
     // Each request should call this method before responding.
     // `error_code' : Error code obtained from the controller, 0 means success.

--- a/src/brpc/details/method_status.h
+++ b/src/brpc/details/method_status.h
@@ -36,7 +36,7 @@ public:
     // Call this function when the method is about to be called.
     // Returns false when the method is overloaded. If rejected_cc is not
     // NULL, it's set with the rejected concurrency.
-    bool OnRequested(int* rejected_cc = NULL);
+    bool OnRequested(int* rejected_cc = NULL, int64_t waiting_us = 0);
 
     // Call this when the method just finished.
     // `error_code' : The error code obtained from the controller. Equal to 
@@ -87,9 +87,9 @@ private:
     uint64_t _received_us;
 };
 
-inline bool MethodStatus::OnRequested(int* rejected_cc) {
+inline bool MethodStatus::OnRequested(int* rejected_cc, int64_t waiting_us) {
     const int cc = _nconcurrency.fetch_add(1, butil::memory_order_relaxed) + 1;
-    if (NULL == _cl || _cl->OnRequested(cc)) {
+    if (NULL == _cl || _cl->OnRequested(cc, waiting_us)) {
         return true;
     } 
     if (rejected_cc) {

--- a/src/brpc/global.cpp
+++ b/src/brpc/global.cpp
@@ -69,6 +69,7 @@
 #include "brpc/concurrency_limiter.h"
 #include "brpc/policy/auto_concurrency_limiter.h"
 #include "brpc/policy/constant_concurrency_limiter.h"
+#include "brpc/policy/codel_concurrency_limiter.h"
 
 #include "brpc/input_messenger.h"     // get_or_new_client_side_messenger
 #include "brpc/socket_map.h"          // SocketMapList
@@ -129,6 +130,7 @@ struct GlobalExtensions {
     DynPartLoadBalancer dynpart_lb;
 
     AutoConcurrencyLimiter auto_cl;
+    CodelConcurrencyLimiter codel_cl;
     ConstantConcurrencyLimiter constant_cl;
 };
 
@@ -564,6 +566,7 @@ static void GlobalInitializeOrDieImpl() {
 
     // Concurrency Limiters
     ConcurrencyLimiterExtension()->RegisterOrDie("auto", &g_ext->auto_cl);
+    ConcurrencyLimiterExtension()->RegisterOrDie("codel", &g_ext->codel_cl);
     ConcurrencyLimiterExtension()->RegisterOrDie("constant", &g_ext->constant_cl);
     
     if (FLAGS_usercode_in_pthread) {

--- a/src/brpc/policy/auto_concurrency_limiter.cpp
+++ b/src/brpc/policy/auto_concurrency_limiter.cpp
@@ -86,7 +86,7 @@ AutoConcurrencyLimiter* AutoConcurrencyLimiter::New(const AdaptiveMaxConcurrency
     return new (std::nothrow) AutoConcurrencyLimiter;
 }
 
-bool AutoConcurrencyLimiter::OnRequested(int current_concurrency) {
+bool AutoConcurrencyLimiter::OnRequested(int current_concurrency, int64_t /*waiting_us*/) {
     return current_concurrency <= _max_concurrency;
 }
 

--- a/src/brpc/policy/auto_concurrency_limiter.h
+++ b/src/brpc/policy/auto_concurrency_limiter.h
@@ -28,7 +28,7 @@ class AutoConcurrencyLimiter : public ConcurrencyLimiter {
 public:
     AutoConcurrencyLimiter();
 
-    bool OnRequested(int current_concurrency) override;
+    bool OnRequested(int current_concurrency, int64_t /*waiting_us*/) override;
     
     void OnResponded(int error_code, int64_t latency_us) override;
 

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -436,7 +436,8 @@ void ProcessRpcRequest(InputMessageBase* msg_base) {
         method_status = mp->status;
         if (method_status) {
             int rejected_cc = 0;
-            if (!method_status->OnRequested(&rejected_cc)) {
+            if (!method_status->OnRequested(&rejected_cc, 
+                    start_parse_us - msg->received_us())) {
                 cntl->SetFailed(ELIMIT, "Rejected by %s's ConcurrencyLimiter, concurrency=%d",
                                 mp->method->full_name().c_str(), rejected_cc);
                 break;

--- a/src/brpc/policy/codel_concurrency_limiter.cpp
+++ b/src/brpc/policy/codel_concurrency_limiter.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2014 Baidu, Inc.G
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Lei He (helei@qiyi.com)
+
+#include <cmath>
+#include <gflags/gflags.h>
+#include <bvar/bvar.h>
+#include "brpc/errno.pb.h"
+#include "brpc/policy/codel_concurrency_limiter.h"
+
+namespace brpc {
+namespace policy {
+
+DEFINE_double(codel_cl_queuing_delay_threshold_ms, 0.15, 
+    "It will be taken to be overloaded if the queuing delay exceeds this time");
+DEFINE_double(codel_cl_discard_timeout_ms, 0.3, 
+    "When the queuing delay exceeds this value, some requests are "
+    "discarded directly");
+DEFINE_double(codel_cl_max_queuing_delay_ms, 1.5, 
+    "The maximum queuing delay that can be tolerated.");
+
+CodelConcurrencyLimiter::CodelConcurrencyLimiter()
+    : _reset_delay(true)
+    , _overloaded(false) 
+    , _min_delay_us(0)
+    , _reset_delay_after_this_time_us(butil::cpuwide_time_us()) {
+}
+
+CodelConcurrencyLimiter* CodelConcurrencyLimiter::New(const AdaptiveMaxConcurrency&) const {
+    return new (std::nothrow) CodelConcurrencyLimiter;
+}
+
+bool CodelConcurrencyLimiter::OnRequested(int current_concurrency, int64_t waiting_us) {
+    return !AnalyzeLoad(waiting_us);
+}
+
+void CodelConcurrencyLimiter::OnResponded(int /*error_code*/, int64_t /*latency_us*/) {
+    return;
+}
+
+int CodelConcurrencyLimiter::MaxConcurrency() {
+    return 0;
+}
+
+bool CodelConcurrencyLimiter::AnalyzeLoad(uint64_t waiting_us) {
+    bool ret = false;
+    uint64_t now_us = butil::cpuwide_time_us();
+    uint64_t min_delay_us = _min_delay_us.load(butil::memory_order_relaxed);
+    
+    const uint64_t interval_us = FLAGS_codel_cl_max_queuing_delay_ms * 1000;
+    const uint64_t delay_threshold_us = FLAGS_codel_cl_queuing_delay_threshold_ms * 1000;
+    if (now_us > _reset_delay_after_this_time_us.load(butil::memory_order_relaxed) &&
+        (!_reset_delay.load(butil::memory_order_acquire) &&
+         !_reset_delay.exchange(true))) {
+        _reset_delay_after_this_time_us.store(now_us + interval_us, 
+            butil::memory_order_relaxed);
+        _overloaded.store(min_delay_us > delay_threshold_us, butil::memory_order_relaxed);
+    }
+
+    if (_reset_delay.load(butil::memory_order_acquire) &&
+        _reset_delay.exchange(false)) {
+        _min_delay_us.store(waiting_us);
+        return false;
+    } else {
+        while (waiting_us < min_delay_us) {
+            if (_min_delay_us.compare_exchange_weak(min_delay_us, waiting_us, 
+                butil::memory_order_relaxed)) {
+                break;
+            }
+        }
+    }
+
+    if ((_overloaded.load(butil::memory_order_relaxed) && 
+            waiting_us > discard_timeout_us()) ||
+        waiting_us > interval_us) {
+        ret = true;
+    }
+    return ret;
+}
+
+uint64_t CodelConcurrencyLimiter::discard_timeout_us() const { 
+    return FLAGS_codel_cl_discard_timeout_ms * 1000; 
+}
+
+}  // namespace policy
+}  // namespace brpc

--- a/src/brpc/policy/codel_concurrency_limiter.cpp
+++ b/src/brpc/policy/codel_concurrency_limiter.cpp
@@ -16,34 +16,40 @@
 
 #include <cmath>
 #include <gflags/gflags.h>
-#include <bvar/bvar.h>
 #include "brpc/errno.pb.h"
 #include "brpc/policy/codel_concurrency_limiter.h"
 
 namespace brpc {
 namespace policy {
 
-DEFINE_double(codel_cl_queuing_delay_threshold_ms, 0.15, 
+DEFINE_double(codel_cl_queuing_delay_threshold_ms, 1, 
     "It will be taken to be overloaded if the queuing delay exceeds this time");
-DEFINE_double(codel_cl_discard_timeout_ms, 0.3, 
+DEFINE_double(codel_cl_discard_timeout_ms, 1.5, 
     "When the queuing delay exceeds this value, some requests are "
     "discarded directly");
-DEFINE_double(codel_cl_max_queuing_delay_ms, 1.5, 
+DEFINE_double(codel_cl_max_queuing_delay_ms, 2, 
     "The maximum queuing delay that can be tolerated.");
+DEFINE_int32(codel_cl_tokens_produced_per_second, 300, 
+    "The number of tokens produced per second. Each token will cause the "
+    "server to process one request that should have been rejected. If the "
+    "tokens are not fully consumed, they will not accumulate to the next second.");
 
 CodelConcurrencyLimiter::CodelConcurrencyLimiter()
-    : _reset_delay(true)
-    , _overloaded(false) 
+    : _realtime_tokens(FLAGS_codel_cl_tokens_produced_per_second)
     , _min_delay_us(0)
-    , _reset_delay_after_this_time_us(butil::cpuwide_time_us()) {
+    , _reset_min_delay_after_this_time_us(butil::cpuwide_time_us() + 
+        FLAGS_codel_cl_max_queuing_delay_ms * 1000)
+    , _reset_tokens_after_this_time_us(butil::cpuwide_time_us() +
+        1000000)
+    , _overloaded(false) {
 }
 
 CodelConcurrencyLimiter* CodelConcurrencyLimiter::New(const AdaptiveMaxConcurrency&) const {
     return new (std::nothrow) CodelConcurrencyLimiter;
 }
 
-bool CodelConcurrencyLimiter::OnRequested(int current_concurrency, int64_t waiting_us) {
-    return !AnalyzeLoad(waiting_us);
+bool CodelConcurrencyLimiter::OnRequested(int current_concurrency, int64_t waiting_time_us) {
+    return !AnalyzeLoad(waiting_time_us);
 }
 
 void CodelConcurrencyLimiter::OnResponded(int /*error_code*/, int64_t /*latency_us*/) {
@@ -57,35 +63,45 @@ int CodelConcurrencyLimiter::MaxConcurrency() {
 bool CodelConcurrencyLimiter::AnalyzeLoad(uint64_t waiting_us) {
     bool ret = false;
     uint64_t now_us = butil::cpuwide_time_us();
+
+    uint64_t reset_tokens_after_this_time_us =
+        _reset_tokens_after_this_time_us.load(butil::memory_order_relaxed);
+    if (now_us > reset_tokens_after_this_time_us &&
+        _reset_tokens_after_this_time_us.compare_exchange_strong(
+            reset_tokens_after_this_time_us, 
+            reset_tokens_after_this_time_us + 1000000,
+            butil::memory_order_relaxed)) {
+        _realtime_tokens.store(FLAGS_codel_cl_tokens_produced_per_second, 
+                          butil::memory_order_relaxed);
+    }   
+
     uint64_t min_delay_us = _min_delay_us.load(butil::memory_order_relaxed);
-    
     const uint64_t interval_us = FLAGS_codel_cl_max_queuing_delay_ms * 1000;
     const uint64_t delay_threshold_us = FLAGS_codel_cl_queuing_delay_threshold_ms * 1000;
-    if (now_us > _reset_delay_after_this_time_us.load(butil::memory_order_relaxed) &&
-        (!_reset_delay.load(butil::memory_order_acquire) &&
-         !_reset_delay.exchange(true))) {
-        _reset_delay_after_this_time_us.store(now_us + interval_us, 
-            butil::memory_order_relaxed);
-        _overloaded.store(min_delay_us > delay_threshold_us, butil::memory_order_relaxed);
-    }
-
-    if (_reset_delay.load(butil::memory_order_acquire) &&
-        _reset_delay.exchange(false)) {
-        _min_delay_us.store(waiting_us);
+    uint64_t reset_min_delay_after_this_time_us = 
+        _reset_min_delay_after_this_time_us.load(butil::memory_order_relaxed);
+    if (now_us > reset_min_delay_after_this_time_us &&
+        _reset_min_delay_after_this_time_us.compare_exchange_strong(
+            reset_min_delay_after_this_time_us, 
+            reset_min_delay_after_this_time_us + interval_us,
+            butil::memory_order_relaxed)) {
+        _overloaded.store(min_delay_us > delay_threshold_us, 
+                          butil::memory_order_relaxed);
+        _min_delay_us.store(waiting_us, butil::memory_order_relaxed);
         return false;
-    } else {
-        while (waiting_us < min_delay_us) {
-            if (_min_delay_us.compare_exchange_weak(min_delay_us, waiting_us, 
-                butil::memory_order_relaxed)) {
-                break;
-            }
+    } 
+    
+    while (waiting_us < min_delay_us) {
+        if (_min_delay_us.compare_exchange_weak(min_delay_us, waiting_us, 
+            butil::memory_order_relaxed)) {
+            break;
         }
     }
 
-    if ((_overloaded.load(butil::memory_order_relaxed) && 
-            waiting_us > discard_timeout_us()) ||
+    if ((_overloaded.load(butil::memory_order_relaxed) 
+        && waiting_us > discard_timeout_us()) ||
         waiting_us > interval_us) {
-        ret = true;
+        ret = _realtime_tokens.fetch_sub(1, butil::memory_order_relaxed) <= 0;
     }
     return ret;
 }

--- a/src/brpc/policy/codel_concurrency_limiter.h
+++ b/src/brpc/policy/codel_concurrency_limiter.h
@@ -36,8 +36,9 @@ public:
 
     int MaxConcurrency() override;
 
-    int current_load_in_percent() const {
-        return 100 * _min_delay_us.load(butil::memory_order_relaxed) / discard_timeout_us();
+    int current_load_in_precent() const {
+        return std::min<int>(100, 
+            100 * _min_delay_us.load(butil::memory_order_relaxed) / discard_timeout_us());
     }
 
 private:
@@ -47,10 +48,15 @@ private:
     // will be discarded.
     uint64_t discard_timeout_us() const;
 
-    std::atomic<bool> _reset_delay;
+    // write per request
+    std::atomic<int32_t> _realtime_tokens;
+    std::atomic<uint64_t> _min_delay_us;
+    std::atomic<uint64_t> _reset_min_delay_after_this_time_us;
+    std::atomic<uint64_t> _reset_tokens_after_this_time_us;
+
+    // write per interval
+    std::atomic<bool> _reset_min_delay;
     std::atomic<bool> _overloaded;
-    std::atomic<uint64_t> BAIDU_CACHELINE_ALIGNMENT _min_delay_us;
-    std::atomic<uint64_t> _reset_delay_after_this_time_us;
 };
 
 }  // namespace policy

--- a/src/brpc/policy/codel_concurrency_limiter.h
+++ b/src/brpc/policy/codel_concurrency_limiter.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2014 Baidu, Inc.G
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Lei He (helei@qiyi.com)
+
+#ifndef BRPC_POLICY_CODEL_CONCURRENCY_LIMITER_H
+#define BRPC_POLICY_CODEL_CONCURRENCY_LIMITER_H
+
+#include "bvar/bvar.h"
+#include "butil/containers/bounded_queue.h"
+#include "brpc/concurrency_limiter.h"
+
+namespace brpc {
+namespace policy {
+
+class CodelConcurrencyLimiter : public ConcurrencyLimiter {
+public:
+    CodelConcurrencyLimiter();
+
+    bool OnRequested(int current_concurrency, int64_t waiting_time_us) override;
+    
+    void OnResponded(int error_code, int64_t latency_us) override;
+
+    CodelConcurrencyLimiter* New(const AdaptiveMaxConcurrency&) const override;
+
+    int MaxConcurrency() override;
+
+    int current_load_in_percent() const {
+        return 100 * _min_delay_us.load(butil::memory_order_relaxed) / discard_timeout_us();
+    }
+
+private:
+    // Analyze current load. Return true if overloaded, otherwise return false
+    bool AnalyzeLoad(uint64_t waiting_us);
+    // When overloaded, the request request whose queuing delay exceeds this timeout 
+    // will be discarded.
+    uint64_t discard_timeout_us() const;
+
+    std::atomic<bool> _reset_delay;
+    std::atomic<bool> _overloaded;
+    std::atomic<uint64_t> BAIDU_CACHELINE_ALIGNMENT _min_delay_us;
+    std::atomic<uint64_t> _reset_delay_after_this_time_us;
+};
+
+}  // namespace policy
+}  // namespace brpc
+
+
+#endif // BRPC_POLICY_CODEL_CONCURRENCY_LIMITER_H

--- a/src/brpc/policy/constant_concurrency_limiter.cpp
+++ b/src/brpc/policy/constant_concurrency_limiter.cpp
@@ -23,7 +23,8 @@ ConstantConcurrencyLimiter::ConstantConcurrencyLimiter(int max_concurrency)
     : _max_concurrency(max_concurrency) {
 }
 
-bool ConstantConcurrencyLimiter::OnRequested(int current_concurrency) {
+bool ConstantConcurrencyLimiter::OnRequested(int current_concurrency, 
+                                             int64_t /*waiting_us*/) {
     return current_concurrency <= _max_concurrency;
 }
 

--- a/src/brpc/policy/constant_concurrency_limiter.h
+++ b/src/brpc/policy/constant_concurrency_limiter.h
@@ -26,7 +26,7 @@ class ConstantConcurrencyLimiter : public ConcurrencyLimiter {
 public:
     explicit ConstantConcurrencyLimiter(int max_concurrency);
     
-    bool OnRequested(int current_concurrency) override;
+    bool OnRequested(int current_concurrency, int64_t /*waiting_us*/) override;
     
     void OnResponded(int error_code, int64_t latency_us) override;
 

--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -1169,7 +1169,8 @@ void ProcessHttpRequest(InputMessageBase *msg) {
     MethodStatus* method_status = sp->status;
     if (method_status) {
         int rejected_cc = 0;
-        if (!method_status->OnRequested(&rejected_cc)) {
+        if (!method_status->OnRequested(&rejected_cc, 
+                start_parse_us - msg->received_us())) {
             cntl->SetFailed(ELIMIT, "Rejected by %s's ConcurrencyLimiter, concurrency=%d",
                             sp->method->full_name().c_str(), rejected_cc);
             return SendHttpResponse(cntl.release(), server, method_status, msg->received_us());


### PR DESCRIPTION
根据codel队列管理算法演变而来的限流算法，以排队时间(start_parsed_us - received_us)作为判断服务是否过载的依据，并且允许短时间的超载。
1. 优点是在服务未满载、qps/latency发生波动时，预期之外的ELIMIT错误非常少。
2. 缺陷是当性能瓶颈是下游服务时，并不能对下游服务起到保护作用