### PR TITLE
Fix compile error in thrift_protocol.cpp under macOS

### DIFF
--- a/src/brpc/policy/thrift_protocol.cpp
+++ b/src/brpc/policy/thrift_protocol.cpp
@@ -49,7 +49,7 @@
 #endif
 
 extern "C" {
-void bthread_assign_data(void* data) __THROW;
+void bthread_assign_data(void* data);
 }
 
 namespace brpc {


### PR DESCRIPTION
Compile error:

/tmp/brpc-20180926-16463-1e3avfz/brpc-a9e954879fda1c63f0f772b47d87943129e5af1f/src/brpc/policy/thrift_protocol.cpp:52:38: error: expected function body after function declarator
void bthread_assign_data(void* data) __THROW;

__THROW is only defined in glibc, which cannot be used in non-glibc systems.
As none of the other protocol uses __THROW for the same function, I assume it is safe to remove
(or replace it with 'noexcept' specifier in standard C++11).