### PR TITLE
Exposing the status of CircuitBreaker to the builtIn page

### DIFF
--- a/src/brpc/builtin/connections_service.cpp
+++ b/src/brpc/builtin/connections_service.cpp
@@ -122,6 +122,9 @@ void ConnectionsService::PrintConnections(
         os << "<th>SSL</th>"
             "<th>Protocol</th>"
             "<th>fd</th>"
+            "<th>error_count</th>"
+            "<th>health_index</th>"
+            "<th>broken_times</th>"
             "<th>InBytes/s</th>"
             "<th>In/s</th>"
             "<th>InBytes/m</th>"
@@ -139,6 +142,7 @@ void ConnectionsService::PrintConnections(
             os << "Local|";
         }
         os << "SSL|Protocol    |fd   |"
+            "error_count|health_index|broken_times|"
             "InBytes/s|In/s  |InBytes/m |In/m    |"
             "OutBytes/s|Out/s |OutBytes/m|Out/m   |"
             "Rtt/Var(ms)|SocketId\n";
@@ -177,6 +181,9 @@ void ConnectionsService::PrintConnections(
             os << min_width("-", 3) << bar
                << min_width("-", 12) << bar
                << min_width("-", 5) << bar
+               << min_width(ptr->error_count(), 11) << bar
+               << min_width("0", 12) << bar
+               << min_width(ptr->broken_times(), 12) << bar
                << min_width("-", 9) << bar
                << min_width("-", 6) << bar
                << min_width("-", 10) << bar
@@ -288,7 +295,10 @@ void ConnectionsService::PrintConnections(
             } else {
                 os << min_width("-", 5) << bar;
             }
-            os << min_width(stat.in_size_s, 9) << bar
+            os << min_width(ptr->error_count(), 11) << bar
+               << min_width(ptr->health_index_in_percent(), 12) << bar
+               << min_width(ptr->broken_times(), 12) << bar
+               << min_width(stat.in_size_s, 9) << bar
                << min_width(stat.in_num_messages_s, 6) << bar
                << min_width(stat.in_size_m, 10) << bar
                << min_width(stat.in_num_messages_m, 8) << bar

--- a/src/brpc/builtin/connections_service.cpp
+++ b/src/brpc/builtin/connections_service.cpp
@@ -122,6 +122,8 @@ void ConnectionsService::PrintConnections(
         os << "<th>SSL</th>"
             "<th>Protocol</th>"
             "<th>fd</th>"
+            "<th>recent_err</th>"
+            "<th>nbreak</th>"
             "<th>InBytes/s</th>"
             "<th>In/s</th>"
             "<th>InBytes/m</th>"
@@ -138,7 +140,7 @@ void ConnectionsService::PrintConnections(
         if (need_local) {
             os << "Local|";
         }
-        os << "SSL|Protocol    |fd   |"
+        os << "SSL|Protocol    |fd   |recent_err|nbreak|"
             "InBytes/s|In/s  |InBytes/m |In/m    |"
             "OutBytes/s|Out/s |OutBytes/m|Out/m   |"
             "Rtt/Var(ms)|SocketId\n";
@@ -174,9 +176,12 @@ void ConnectionsService::PrintConnections(
             if (need_local) {
                 os << min_width(ptr->local_side().port, 5) << bar;
             }
+
             os << min_width("-", 3) << bar
                << min_width("-", 12) << bar
                << min_width("-", 5) << bar
+               << min_width(ptr->recent_error_count(), 11) << bar
+               << min_width(ptr->isolated_times(), 7) << bar
                << min_width("-", 9) << bar
                << min_width("-", 6) << bar
                << min_width("-", 10) << bar
@@ -288,7 +293,9 @@ void ConnectionsService::PrintConnections(
             } else {
                 os << min_width("-", 5) << bar;
             }
-            os << min_width(stat.in_size_s, 9) << bar
+            os << min_width(ptr->recent_error_count(), 11) << bar
+               << min_width(ptr->isolated_times(), 7) << bar
+               << min_width(stat.in_size_s, 9) << bar
                << min_width(stat.in_num_messages_s, 6) << bar
                << min_width(stat.in_size_m, 10) << bar
                << min_width(stat.in_num_messages_m, 8) << bar

--- a/src/brpc/builtin/connections_service.cpp
+++ b/src/brpc/builtin/connections_service.cpp
@@ -122,7 +122,6 @@ void ConnectionsService::PrintConnections(
         os << "<th>SSL</th>"
             "<th>Protocol</th>"
             "<th>fd</th>"
-            "<th>acc_errors</th>"
             "<th>InBytes/s</th>"
             "<th>In/s</th>"
             "<th>InBytes/m</th>"
@@ -139,7 +138,7 @@ void ConnectionsService::PrintConnections(
         if (need_local) {
             os << "Local|";
         }
-        os << "SSL|Protocol    |fd   |acc_errors|"
+        os << "SSL|Protocol    |fd   |"
             "InBytes/s|In/s  |InBytes/m |In/m    |"
             "OutBytes/s|Out/s |OutBytes/m|Out/m   |"
             "Rtt/Var(ms)|SocketId\n";
@@ -178,7 +177,6 @@ void ConnectionsService::PrintConnections(
             os << min_width("-", 3) << bar
                << min_width("-", 12) << bar
                << min_width("-", 5) << bar
-               << min_width(ptr->acc_errors(), 10) << bar
                << min_width("-", 9) << bar
                << min_width("-", 6) << bar
                << min_width("-", 10) << bar
@@ -290,8 +288,7 @@ void ConnectionsService::PrintConnections(
             } else {
                 os << min_width("-", 5) << bar;
             }
-            os << min_width(ptr->acc_errors(), 10) << bar
-               << min_width(stat.in_size_s, 9) << bar
+            os << min_width(stat.in_size_s, 9) << bar
                << min_width(stat.in_num_messages_s, 6) << bar
                << min_width(stat.in_size_m, 10) << bar
                << min_width(stat.in_num_messages_m, 8) << bar

--- a/src/brpc/builtin/connections_service.cpp
+++ b/src/brpc/builtin/connections_service.cpp
@@ -122,9 +122,7 @@ void ConnectionsService::PrintConnections(
         os << "<th>SSL</th>"
             "<th>Protocol</th>"
             "<th>fd</th>"
-            "<th>error_count</th>"
-            "<th>health_index</th>"
-            "<th>broken_times</th>"
+            "<th>acc_errors</th>"
             "<th>InBytes/s</th>"
             "<th>In/s</th>"
             "<th>InBytes/m</th>"
@@ -141,8 +139,7 @@ void ConnectionsService::PrintConnections(
         if (need_local) {
             os << "Local|";
         }
-        os << "SSL|Protocol    |fd   |"
-            "error_count|health_index|broken_times|"
+        os << "SSL|Protocol    |fd   |acc_errors|"
             "InBytes/s|In/s  |InBytes/m |In/m    |"
             "OutBytes/s|Out/s |OutBytes/m|Out/m   |"
             "Rtt/Var(ms)|SocketId\n";
@@ -181,9 +178,7 @@ void ConnectionsService::PrintConnections(
             os << min_width("-", 3) << bar
                << min_width("-", 12) << bar
                << min_width("-", 5) << bar
-               << min_width(ptr->error_count(), 11) << bar
-               << min_width("0", 12) << bar
-               << min_width(ptr->broken_times(), 12) << bar
+               << min_width(ptr->acc_errors(), 10) << bar
                << min_width("-", 9) << bar
                << min_width("-", 6) << bar
                << min_width("-", 10) << bar
@@ -295,9 +290,7 @@ void ConnectionsService::PrintConnections(
             } else {
                 os << min_width("-", 5) << bar;
             }
-            os << min_width(ptr->error_count(), 11) << bar
-               << min_width(ptr->health_index_in_percent(), 12) << bar
-               << min_width(ptr->broken_times(), 12) << bar
+            os << min_width(ptr->acc_errors(), 10) << bar
                << min_width(stat.in_size_s, 9) << bar
                << min_width(stat.in_num_messages_s, 6) << bar
                << min_width(stat.in_size_m, 10) << bar

--- a/src/brpc/circuit_breaker.cpp
+++ b/src/brpc/circuit_breaker.cpp
@@ -21,9 +21,9 @@
 
 namespace brpc {
 
-DEFINE_int32(circuit_breaker_short_window_size, 500,
+DEFINE_int32(circuit_breaker_short_window_size, 1500,
     "Short window sample size.");
-DEFINE_int32(circuit_breaker_long_window_size, 1000,
+DEFINE_int32(circuit_breaker_long_window_size, 3000,
     "Long window sample size.");
 DEFINE_int32(circuit_breaker_short_window_error_percent, 10,
     "The maximum error rate allowed by the short window, ranging from 0-99.");
@@ -39,6 +39,8 @@ DEFINE_int32(circuit_breaker_min_isolation_duration_ms, 100,
     "Minimum isolation duration in milliseconds");
 DEFINE_int32(circuit_breaker_max_isolation_duration_ms, 30000,
     "Maximum isolation duration in milliseconds");
+DEFINE_double(circuit_breaker_epsilon_value, 0.02, 
+    "ema_alpha = 1 - std::pow(epsilon, 1.0 / window_size)");
 
 namespace {
 // EPSILON is used to generate the smoothing coefficient when calculating EMA.
@@ -51,7 +53,9 @@ namespace {
 // when window_size = 1000,
 // EPSILON = 0.1, smooth = 0.9977
 // EPSILON = 0.3, smooth = 0.9987
-const double EPSILON = 0.1;
+
+#define EPSILON (FLAGS_circuit_breaker_epsilon_value)
+
 }  // namepace
 
 CircuitBreaker::EmaErrorRecorder::EmaErrorRecorder(int window_size,

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -52,13 +52,13 @@ public:
 
     // Number of times marked as broken
     int isolated_times() const {
-        return _isolated_times;
+        return _isolated_times.load(butil::memory_order_relaxed);
     }
 
     // The duration that should be isolated when the socket fails in milliseconds.
     // The higher the frequency of socket errors, the longer the duration.
     int isolation_duration_ms() const {
-        return _isolation_duration_ms;
+        return _isolation_duration_ms.load(butil::memory_order_relaxed);
     }
 
 private:
@@ -89,8 +89,8 @@ private:
     EmaErrorRecorder _long_window;
     EmaErrorRecorder _short_window;
     int64_t _last_reset_time_ms; 
-    int _isolation_duration_ms;
-    int _isolated_times;
+    butil::atomic<int> _isolation_duration_ms;
+    butil::atomic<int> _isolated_times;
     butil::atomic<bool> _broken;
 };
 

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -46,10 +46,6 @@ public:
     // only the first call will take effect.
     void MarkAsBroken();
 
-    // The closer to 100, the less recent errors occurred, and 0 means that 
-    // it should be isolated.
-    int health_score() const;
-
     // Number of times marked as broken
     int isolated_times() const {
         return _isolated_times.load(butil::memory_order_relaxed);
@@ -70,7 +66,6 @@ private:
         bool OnCallEnd(int error_code, int64_t latency);
         void Reset();
 
-        int64_t max_error_cost() const;
         int health_score() const;
      
     private:

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -66,8 +66,6 @@ private:
         bool OnCallEnd(int error_code, int64_t latency);
         void Reset();
 
-        int health_score() const;
-     
     private:
         int64_t UpdateLatency(int64_t latency);
         bool UpdateErrorCost(int64_t latency, int64_t ema_latency);

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -33,12 +33,12 @@ public:
     // latency: Time cost of this call.
     // Note: Once OnCallEnd() determined that a node needs to be isolated,
     // it will always return false until you call Reset(). Usually Reset() 
-    // will be called in the health check thread. 
+    // will be called in the health check thread.
     bool OnCallEnd(int error_code, int64_t latency);
 
     // Reset CircuitBreaker and clear history data. will erase the historical 
     // data and start sampling again. Before you call this method, you need to
-    // ensure that no one else is calling OnCallEnd.
+    // ensure that no one else is accessing CircuitBreaker.
     void Reset();
 
     // Mark the Socket as broken. Call this method when you want to isolate a 

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -38,11 +38,15 @@ public:
     // ensure that no one else is calling OnCallEnd.
     void Reset();
 
-    // Not thread-safe
+    // Mark the Socket as broken. You should NOT call this method multiple 
+    // times in succession.
     void MarkAsBroken();
 
+    // The closer to 100, the less recent errors occurred, and 0 means that 
+    // it should be isolated.
     int health_index_in_percent() const;
 
+    // Number of times marked as broken
     int broken_times() const {
         return _broken_times;
     }

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -44,11 +44,11 @@ public:
 
     // The closer to 100, the less recent errors occurred, and 0 means that 
     // it should be isolated.
-    int health_index_in_percent() const;
+    int health_score() const;
 
     // Number of times marked as broken
-    int broken_times() const {
-        return _broken_times;
+    int isolated_times() const {
+        return _isolated_times;
     }
 
     // The duration that should be isolated when the socket fails in milliseconds.
@@ -67,7 +67,7 @@ private:
         void Reset();
 
         int64_t max_error_cost() const;
-        int health_index_in_percent() const;
+        int health_score() const;
      
     private:
         int64_t UpdateLatency(int64_t latency);
@@ -86,7 +86,7 @@ private:
     EmaErrorRecorder _short_window;
     int64_t _last_reset_time_ms; 
     int _isolation_duration_ms;
-    int _broken_times;
+    int _isolated_times;
 };
 
 }  // namespace brpc

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -700,6 +700,9 @@ void Controller::Call::OnComplete(
         sending_sock->FeedbackCircuitBreaker(error_code, 
             butil::gettimeofday_us() - begin_time_us);
     }
+    if (error_code != 0 && sending_sock) {
+        sending_sock->AddErrorCount();
+    }
  
     switch (c->connection_type()) {
     case CONNECTION_TYPE_UNKNOWN:
@@ -765,7 +768,7 @@ void Controller::Call::OnComplete(
             sock->SetLogOff();
         }
     }
-   
+    
     if (need_feedback) {
         const LoadBalancer::CallInfo info =
             { begin_time_us, peer_id, error_code, c };

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -701,10 +701,9 @@ void Controller::Call::OnComplete(
         stream_user_data = NULL;
     }
 
-    if (sending_sock) {
-        sending_sock->AddRequestCount();
+    if (sending_sock != NULL) {
         if (error_code != 0) {
-            sending_sock->AddErrorCount();
+            sending_sock->AddRecentError();
         }
 
         if (enable_circuit_breaker) {

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -696,14 +696,23 @@ inline bool does_error_affect_main_socket(int error_code) {
 //      entire RPC (specified by c->FailedInline()).
 void Controller::Call::OnComplete(
         Controller* c, int error_code/*note*/, bool responded, bool end_of_rpc) {
-    if (enable_circuit_breaker && sending_sock) {
-        sending_sock->FeedbackCircuitBreaker(error_code, 
-            butil::gettimeofday_us() - begin_time_us);
+    if (stream_user_data) {
+        stream_user_data->DestroyStreamUserData(sending_sock, c, error_code, end_of_rpc);
+        stream_user_data = NULL;
     }
-    if (error_code != 0 && sending_sock) {
-        sending_sock->AddErrorCount();
+
+    if (sending_sock) {
+        sending_sock->AddRequestCount();
+        if (error_code != 0) {
+            sending_sock->AddErrorCount();
+        }
+
+        if (enable_circuit_breaker) {
+            sending_sock->FeedbackCircuitBreaker(error_code, 
+                butil::gettimeofday_us() - begin_time_us);
+        }
     }
- 
+
     switch (c->connection_type()) {
     case CONNECTION_TYPE_UNKNOWN:
         break;
@@ -774,11 +783,6 @@ void Controller::Call::OnComplete(
         const LoadBalancer::CallInfo info =
             { begin_time_us, peer_id, error_code, c };
         c->_lb->Feedback(info);
-    }
-
-    if (stream_user_data) {
-        stream_user_data->DestroyStreamUserData(sending_sock, c, error_code, end_of_rpc);
-        stream_user_data = NULL;
     }
 
     // Release the `Socket' we used to send/receive data

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -761,6 +761,7 @@ void Controller::Call::OnComplete(
         }
         break;
     }
+
     if (ELOGOFF == error_code) {
         SocketUniquePtr sock;
         if (Socket::Address(peer_id, &sock) == 0) {
@@ -768,7 +769,7 @@ void Controller::Call::OnComplete(
             sock->SetLogOff();
         }
     }
-    
+
     if (need_feedback) {
         const LoadBalancer::CallInfo info =
             { begin_time_us, peer_id, error_code, c };

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -850,6 +850,7 @@ int Socket::SetFailed(int error_code, const char* error_fmt, ...) {
                 vref, MakeVRef(id_ver + 1, NRefOfVRef(vref)),
                 butil::memory_order_release,
                 butil::memory_order_relaxed)) {
+            GetOrNewSharedPart()->circuit_breaker.MarkAsBroken();
             // Update _error_text
             std::string error_text;
             if (error_fmt != NULL) {

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -196,8 +196,9 @@ Socket::SharedPart::SharedPart(SocketId creator_socket_id2)
     , in_num_messages(0)
     , out_size(0)
     , out_num_messages(0)
-    , extended_stat(NULL) 
-    , acc_errors(0) {
+    , extended_stat(NULL)
+    , acc_errors(0)
+    , acc_requests(0) {
 }
 
 Socket::SharedPart::~SharedPart() {
@@ -818,14 +819,6 @@ void Socket::AddRequestCount() {
     if (sp) {
         sp->acc_requests.fetch_add(1, butil::memory_order_relaxed);
     }
-}
-
-uint64_t Socket::acc_errors() const {
-    SharedPart* sp = GetSharedPart();
-    if (sp) {
-        return sp->acc_errors.load(butil::memory_order_relaxed);
-    }
-    return 0;
 }
 
 int Socket::SetFailed(int error_code, const char* error_fmt, ...) {

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -905,7 +905,6 @@ int Socket::SetFailed() {
 void Socket::FeedbackCircuitBreaker(int error_code, int64_t latency_us) {
     if (!GetOrNewSharedPart()->circuit_breaker.OnCallEnd(error_code, latency_us)) {
         if (SetFailed(main_socket_id()) == 0) {
-            SetFailed(main_socket_id());
             LOG(ERROR) << "Socket[" << *this << "] isolated by circuit breaker";
         }
     }

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -834,7 +834,6 @@ int Socket::SetFailed(int error_code, const char* error_fmt, ...) {
                 vref, MakeVRef(id_ver + 1, NRefOfVRef(vref)),
                 butil::memory_order_release,
                 butil::memory_order_relaxed)) {
-            GetOrNewSharedPart()->circuit_breaker.MarkAsBroken();
             // Update _error_text
             std::string error_text;
             if (error_fmt != NULL) {
@@ -852,6 +851,7 @@ int Socket::SetFailed(int error_code, const char* error_fmt, ...) {
             // by Channel to revive never-connected socket when server side
             // comes online.
             if (_health_check_interval_s > 0) {
+                GetOrNewSharedPart( )->circuit_breaker.MarkAsBroken();
                 PeriodicTaskManager::StartTaskAt(
                     new HealthCheckTask(id()),
                     butil::milliseconds_from_now(GetOrNewSharedPart()->

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -317,9 +317,11 @@ public:
         __attribute__ ((__format__ (__printf__, 3, 4)));
     static int SetFailed(SocketId id);
 
-    void AddErrorCount();
+    void AddRecentError();
 
-    void AddRequestCount();
+    int64_t recent_error_count() const;
+
+    int isolated_times() const;
 
     void FeedbackCircuitBreaker(int error_code, int64_t latency_us);
 

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -319,7 +319,7 @@ public:
 
     void AddErrorCount();
 
-    uint64_t acc_errors() const;
+    void AddRequestCount();
 
     void FeedbackCircuitBreaker(int error_code, int64_t latency_us);
 

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -319,11 +319,7 @@ public:
 
     void AddErrorCount();
 
-    uint64_t error_count() const;
-
-    int broken_times() const;
-
-    int health_index_in_percent() const;
+    uint64_t acc_errors() const;
 
     void FeedbackCircuitBreaker(int error_code, int64_t latency_us);
 

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -317,6 +317,14 @@ public:
         __attribute__ ((__format__ (__printf__, 3, 4)));
     static int SetFailed(SocketId id);
 
+    void AddErrorCount();
+
+    uint64_t error_count() const;
+
+    int broken_times() const;
+
+    int health_index_in_percent() const;
+
     void FeedbackCircuitBreaker(int error_code, int64_t latency_us);
 
     bool Failed() const;

--- a/test/brpc_circuit_breaker_unittest.cpp
+++ b/test/brpc_circuit_breaker_unittest.cpp
@@ -60,14 +60,10 @@ struct FeedbackControl {
         : _req_num(req_num)
         , _error_percent(error_percent)
         , _circuit_breaker(circuit_breaker)
-        , _healthy_cnt(0) 
-        , _unhealthy_cnt(0) 
         , _healthy(true) {}
     int _req_num;
     int _error_percent;
     brpc::CircuitBreaker* _circuit_breaker;
-    int _healthy_cnt;
-    int _unhealthy_cnt;
     bool _healthy;
 };
 
@@ -91,10 +87,8 @@ protected:
                 healthy = fc->_circuit_breaker->OnCallEnd(kErrorCodeForSucc, kLatency);
             }
             fc->_healthy = healthy;
-            if (healthy) {
-                ++fc->_healthy_cnt;
-            } else {
-                ++fc->_unhealthy_cnt;
+            if (!healthy) {
+                break;
             }
         }
         return fc;
@@ -126,9 +120,11 @@ TEST_F(CircuitBreakerTest, should_not_isolate) {
         void* ret_data = NULL;
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
-        EXPECT_EQ(fc->_unhealthy_cnt, 0);
         EXPECT_TRUE(fc->_healthy);
     }
+    // MarkAsBroken shoul be called only once.
+    _circuit_breaker.MarkAsBroken();
+    _circuit_breaker.Reset();
 } 
 
 TEST_F(CircuitBreakerTest, should_isolate) {
@@ -139,12 +135,15 @@ TEST_F(CircuitBreakerTest, should_isolate) {
         void* ret_data = NULL;
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
-        EXPECT_GT(fc->_unhealthy_cnt, 0);
         EXPECT_FALSE(fc->_healthy);
     }
+    // MarkAsBroken shoul be called only once.
+    _circuit_breaker.MarkAsBroken();
+    _circuit_breaker.Reset();
 }
 
 TEST_F(CircuitBreakerTest, isolation_duration_grow) {
+    EXPECT_EQ(_circuit_breaker.isolation_duration_ms(), kMinIsolationDurationMs);
     _circuit_breaker.Reset();
     std::vector<pthread_t> thread_list;
     std::vector<std::unique_ptr<FeedbackControl>> fc_list;
@@ -154,9 +153,9 @@ TEST_F(CircuitBreakerTest, isolation_duration_grow) {
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
         EXPECT_FALSE(fc->_healthy);
-        EXPECT_LE(fc->_healthy_cnt, kShortWindowSize);
-        EXPECT_GT(fc->_unhealthy_cnt, 0);
     }
+    // MarkAsBroken shoul be called only once.
+    _circuit_breaker.MarkAsBroken();
     EXPECT_EQ(_circuit_breaker.isolation_duration_ms(), kMinIsolationDurationMs * 2);
 
     _circuit_breaker.Reset();
@@ -167,9 +166,9 @@ TEST_F(CircuitBreakerTest, isolation_duration_grow) {
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
         EXPECT_FALSE(fc->_healthy);
-        EXPECT_LE(fc->_healthy_cnt, kShortWindowSize);
-        EXPECT_GT(fc->_unhealthy_cnt, 0);
     }
+    // MarkAsBroken shoul be called only once.
+    _circuit_breaker.MarkAsBroken();
     EXPECT_EQ(_circuit_breaker.isolation_duration_ms(), kMinIsolationDurationMs * 4);
 
     _circuit_breaker.Reset();
@@ -180,8 +179,8 @@ TEST_F(CircuitBreakerTest, isolation_duration_grow) {
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
         EXPECT_FALSE(fc->_healthy);
-        EXPECT_LE(fc->_healthy_cnt, kShortWindowSize);
-        EXPECT_GT(fc->_unhealthy_cnt, 0);
     }
+    // MarkAsBroken shoul be called only once.
+    _circuit_breaker.MarkAsBroken();
     EXPECT_EQ(_circuit_breaker.isolation_duration_ms(), kMinIsolationDurationMs);
 }


### PR DESCRIPTION
在SharedPart统计了每个Socket的出错情况，并暴露在connections页面上。
error_count : 总的出错次数
health_index : 100表示没出错，接近0表示即将被熔断)
broken_times : 被SetFailed的次数, 仅记录SetFailed=0的次数
不论是否开启熔断都会进行统计。