### PR TITLE
make braft work in mac OSX

### DIFF
--- a/src/butil/files/dir_reader_posix.h
+++ b/src/butil/files/dir_reader_posix.h
@@ -19,6 +19,8 @@
 
 #if defined(OS_LINUX)
 #include "butil/files/dir_reader_linux.h"
+#elif defined(__APPLE__)
+#include "butil/files/dir_reader_unix.h"
 #else
 #include "butil/files/dir_reader_fallback.h"
 #endif
@@ -27,6 +29,8 @@ namespace butil {
 
 #if defined(OS_LINUX)
 typedef DirReaderLinux DirReaderPosix;
+#elif defined(__APPLE__)
+typedef DirReaderUnix DirReaderPosix;
 #else
 typedef DirReaderFallback DirReaderPosix;
 #endif

--- a/src/butil/files/dir_reader_unix.h
+++ b/src/butil/files/dir_reader_unix.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2018 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Authors: yinqiwen (yinqiwen@gmail.com)
+
+#ifndef BUTIL_FILES_DIR_READER_UNIX_H_
+#define BUTIL_FILES_DIR_READER_UNIX_H_
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <dirent.h>
+
+#include "butil/logging.h"
+#include "butil/posix/eintr_wrapper.h"
+
+// See the comments in dir_reader_posix.h about this.
+
+namespace butil {
+
+class DirReaderUnix {
+ public:
+  explicit DirReaderUnix(const char* directory_path)
+      : fd_(open(directory_path, O_RDONLY | O_DIRECTORY)),
+        dir_(NULL),current_(NULL) {
+      dir_ = fdopendir(fd_);
+  }
+
+  ~DirReaderUnix() {
+    if (fd_ >= 0) {
+      if (IGNORE_EINTR(close(fd_)))
+        RAW_LOG(ERROR, "Failed to close directory handle");
+    }
+    if(NULL != dir_)
+    {
+        closedir(dir_);
+    }
+  }
+
+  bool IsValid() const {
+    return fd_ >= 0;
+  }
+
+  // Move to the next entry returning false if the iteration is complete.
+  bool Next() {
+    int err = readdir_r(dir_,&entry_, &current_);
+    if(0 != err || NULL == current_)
+    {
+        return false;
+    }
+    return true;
+  }
+
+  const char* name() const {
+    if (NULL == current_)
+      return NULL;
+    return current_->d_name;
+  }
+
+  int fd() const {
+    return fd_;
+  }
+
+  static bool IsFallback() {
+    return false;
+  }
+
+ private:
+  const int fd_;
+  DIR* dir_;
+  struct dirent entry_;
+  struct dirent* current_;
+};
+
+}  // namespace butil
+
+#endif // BUTIL_FILES_DIR_READER_LINUX_H_

--- a/src/butil/files/dir_reader_unix.h
+++ b/src/butil/files/dir_reader_unix.h
@@ -44,8 +44,7 @@ class DirReaderUnix {
       if (IGNORE_EINTR(close(fd_)))
         RAW_LOG(ERROR, "Failed to close directory handle");
     }
-    if(NULL != dir_)
-    {
+    if(NULL != dir_){
         closedir(dir_);
     }
   }
@@ -57,8 +56,7 @@ class DirReaderUnix {
   // Move to the next entry returning false if the iteration is complete.
   bool Next() {
     int err = readdir_r(dir_,&entry_, &current_);
-    if(0 != err || NULL == current_)
-    {
+    if(0 != err || NULL == current_){
         return false;
     }
     return true;


### PR DESCRIPTION
1. braft relies on the interface DirReaderPosix's implementation
2. the default DirReaderFallback is empty in OSX