### PR TITLE
add queue mutex & uid barrel & switch for baidu protocol

### DIFF
--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -252,6 +252,8 @@ void Controller::ResetPods() {
     _request_stream = INVALID_STREAM_ID;
     _response_stream = INVALID_STREAM_ID;
     _remote_stream_settings = NULL;
+    _req_uid = 0;
+    _use_uid_barrel = false;
 }
 
 Controller::Call::Call(Controller::Call* rhs)

--- a/src/brpc/controller.h
+++ b/src/brpc/controller.h
@@ -493,6 +493,12 @@ public:
     // -1 means no deadline.
     int64_t deadline_us() const { return _deadline_us; }
 
+    int64_t req_uid() { return _req_uid;}
+    void set_req_uid(int64_t req_uid) { _req_uid = req_uid; }
+
+    bool use_uid_barrel() { return _use_uid_barrel;}
+    void set_use_uid_barrel(bool use_uid_barrel) { _use_uid_barrel = use_uid_barrel;}
+
 private:
     struct CompletionInfo {
         CallId id;           // call_id of the corresponding request
@@ -736,6 +742,13 @@ private:
 
     // Thrift method name, only used when thrift protocol enabled
     std::string _thrift_method_name;
+    
+    //uid in rpc_meta for common use
+    int64_t _req_uid;
+
+    //only valid in server side,setted by ServerOptions,default false
+    bool _use_uid_barrel;
+
 };
 
 // Advises the RPC system that the caller desires that the RPC call be

--- a/src/brpc/policy/baidu_rpc_meta.proto
+++ b/src/brpc/policy/baidu_rpc_meta.proto
@@ -15,6 +15,7 @@ message RpcMeta {
     optional ChunkInfo chunk_info = 6;
     optional bytes authentication_data = 7;
     optional StreamSettings stream_settings = 8;   
+    optional int64 uid = 9;
 }
 
 message RpcRequestMeta {

--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -137,6 +137,7 @@ ServerOptions::ServerOptions()
     , bthread_init_count(0)
     , internal_port(-1) 
     , has_builtin_services(true)
+    , use_uid_barrel(false)
     , http_master_service(NULL)
     , health_reporter(NULL)
     , rtmp_service(NULL) {

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -196,6 +196,9 @@ struct ServerOptions {
     // Default: true
     bool has_builtin_services;
 
+    // default false,when enable,all request with same uid will block in one barrel for serialization
+    bool use_uid_barrel;
+    
     // Enable more secured code which protects internal information from exposure.
     bool security_mode() const { return internal_port >= 0 || !has_builtin_services; }
 

--- a/src/bthread/barrel.cpp
+++ b/src/bthread/barrel.cpp
@@ -1,0 +1,50 @@
+#include "bthread/barrel.h"
+#include "butil/hash.h"
+#include "butil/memory/singleton.h"
+#include <gflags/gflags.h>
+#include <assert.h>
+
+DEFINE_int32(uid_barrel_cnt, 10000, "barrel number for uid barrel");
+
+namespace bthread {
+
+UinBarrel::UinBarrel() {
+    _barrel_cnt = FLAGS_uid_barrel_cnt;
+    _barrel_list = (bthread_queue_mutex_t *)calloc(FLAGS_uid_barrel_cnt, sizeof(bthread_queue_mutex_t));
+    assert(_barrel_list);
+    for(int i=0; i<FLAGS_uid_barrel_cnt; ++i) {
+        if(bthread_queue_mutex_init(&_barrel_list[i],NULL) ) {
+            assert(false);
+        }
+    }
+}
+
+UinBarrel::~UinBarrel() {
+    assert(_barrel_list);
+    for(uint32_t i=0; i<_barrel_cnt; ++i) {
+        bthread_queue_mutex_destroy(&_barrel_list[i]);
+    }
+    free(_barrel_list);
+}
+
+UinBarrel* UinBarrel::GetInstance() {
+    return Singleton<UinBarrel>::get();
+}
+
+int UinBarrel::LockUinBarrel(uint64_t uid) {
+    uint32_t hash_idx = butil::SuperFastHash((const char *)&uid, sizeof(uid))%_barrel_cnt;
+    bthread_queue_mutex_lock(&_barrel_list[hash_idx]);
+    return 0;
+}
+
+int UinBarrel::UnLockUinBarrel(uint64_t uid) {
+    uint32_t hash_idx = butil::SuperFastHash((const char *)&uid, sizeof(uid))%_barrel_cnt;
+    bthread_queue_mutex_unlock(&_barrel_list[hash_idx]);
+    return 0;
+}
+
+inline int UinBarrel::GetBarrelIdx(uint64_t uid) {
+    return (butil::SuperFastHash((const char *)&uid, sizeof(uid))%_barrel_cnt);
+}
+
+} // namespace bthread

--- a/src/bthread/barrel.h
+++ b/src/bthread/barrel.h
@@ -1,5 +1,5 @@
 // uid barrel - a barrel library to make same uid queue up, it's some kind of serialization in brpc.
-// Copyright (c) 2018 Bigo, Inc.
+// Copyright (c) 2018 abstraction No Inc 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bthread/barrel.h
+++ b/src/bthread/barrel.h
@@ -1,0 +1,69 @@
+// uid barrel - a barrel library to make same uid queue up, it's some kind of serialization in brpc.
+// Copyright (c) 2018 Bigo, Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: hairet (hairet@vip.qq.com) 
+// Date: 2018/11/7
+
+#ifndef  BTHREAD_BARREL_H
+#define  BTHREAD_BARREL_H
+
+#include "bthread/types.h"
+#include "bthread/mutex.h"
+#include "butil/scoped_lock.h"
+#include "bvar/utils/lock_timer.h"
+
+namespace bthread {
+
+//all uid will hash into uid_barrel_cnt number barrels, uids in same barrel will queue by LockUinBarrel and UnLockUinBarrel
+//caller can be bthread or pthread, this UinBarrel design for serialization
+class UinBarrel {
+public:
+    UinBarrel();
+    ~UinBarrel();
+    static UinBarrel* GetInstance();
+    
+    //should only return 0
+    int LockUinBarrel(uint64_t uid);
+    
+    int UnLockUinBarrel(uint64_t uid);
+
+    inline int GetBarrelIdx(uint64_t uid);
+
+private:
+    uint32_t _barrel_cnt;   //deafult 10000 barrel
+    bthread_queue_mutex_t *_barrel_list;
+};
+
+class bUinBarrelGaurd {
+public:
+    bUinBarrelGaurd(uint64_t uid) : _uid(uid) {
+        if(uid>0) {
+            UinBarrel::GetInstance()->LockUinBarrel(uid);
+        }
+    }
+    ~bUinBarrelGaurd() {
+        if(_uid>0) {
+            UinBarrel::GetInstance()->UnLockUinBarrel(_uid);
+        }
+    }
+private:
+    uint64_t _uid;
+};
+
+
+} // namespace bthread
+
+#endif  // BTHREAD_BARREL_H 
+

--- a/src/bthread/butex.cpp
+++ b/src/bthread/butex.cpp
@@ -735,8 +735,8 @@ static int queue_butex_wait_from_pthread(TaskGroup* g, Butex* b ) {
         }
         task->ignore_interrupted = false;
     }
-    //FIXME!!check rc maybe safe 
-    if(rc) {
+    //FIXME!!check rc maybe safe,as wait_pthread no timeout,so only PTHREAD_SIGNALLED setted by wakeup_pthread can be here 
+    if(rc && PTHREAD_SIGNALLED != pw.sig.load(butil::memory_order_acquire)) {
         assert(false);
     }
     return 0;

--- a/src/bthread/butex.h
+++ b/src/bthread/butex.h
@@ -23,6 +23,7 @@
 #include <time.h>                                // timespec
 #include "butil/macros.h"                         // BAIDU_CASSERT
 #include "bthread/types.h"                       // bthread_t
+#include "butil/atomicops.h"                // butil::atomic 
 
 namespace bthread {
 
@@ -78,8 +79,7 @@ int queued_butex_wait(void* butex, const timespec* abstime);
 // Returns # of threads woken up.
 // if return 1,set wake_bid
 // when return 0,QueuedMutexInternal::locked will unlock 
-int queued_butex_wake(void* arg, bthread_t &wake_bid);
-
+int queued_butex_wake(void* arg, butil::static_atomic<uint64_t> &wake_bid);
 
 }  // namespace bthread
 

--- a/src/bthread/butex.h
+++ b/src/bthread/butex.h
@@ -67,6 +67,20 @@ int butex_requeue(void* butex1, void* butex2);
 // Returns 0 on success, -1 otherwise and errno is set.
 int butex_wait(void* butex, int expected_value, const timespec* abstime);
 
+//add by haiert 2018.11.6
+//Atomically wait on |butex| ,and take butex->value as QueuedMutexInternal
+//if get QueuedMutex as owner before add wait_queue will return,else can only wake up by queued_butex_wake
+//not support abstime yet,and disable interrupted by ignore_interrupted in task_meta 
+//return 0 when be wake up by queued_butex_wake, when 1 as onwer with no queued_butex_wake 
+int queued_butex_wait(void* butex, const timespec* abstime);
+
+// Wake up at most 1 thread waiting on |butex|.
+// Returns # of threads woken up.
+// if return 1,set wake_bid
+// when return 0,QueuedMutexInternal::locked will unlock 
+int queued_butex_wake(void* arg, bthread_t &wake_bid);
+
+
 }  // namespace bthread
 
 #endif  // BTHREAD_BUTEX_H

--- a/src/bthread/spinlock.h
+++ b/src/bthread/spinlock.h
@@ -1,0 +1,56 @@
+// spin lock - user lib spin lock.caller should pass lock when init
+// carefully use this,as conflict will cause high cost
+// Copyright (c) 2018 Bigo, Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: hairet (hairet@vip.qq.com)
+// Date: Tue Nov 6 17:30:12 CST 2018
+
+#ifndef BTHREAD_SPIN_LOCK_H
+#define BTHREAD_SPIN_LOCK_H
+
+#include "butil/macros.h"
+#include "butil/atomicops.h"
+
+inline void b_spin_lock_init(butil::static_atomic<unsigned char> &m) {
+    m.exchange(0, butil::memory_order_relaxed);
+}
+
+inline void b_spin_lock(butil::static_atomic<unsigned char> &m) {
+    while(m.exchange(1, butil::memory_order_acquire));
+    //FIXME!!later add sample
+}
+
+inline bool b_spin_try_lock(butil::static_atomic<unsigned char> &m) {
+    return !m.exchange(1, butil::memory_order_acquire);
+}
+
+inline void b_spin_unlock(butil::static_atomic<unsigned char> &m) {
+    m.exchange(0, butil::memory_order_release);
+}
+
+class bSpinLockGaurd {
+public:
+    bSpinLockGaurd(butil::static_atomic<unsigned char> &m) : m_lock(&m) {
+        b_spin_lock(*m_lock);
+    }
+    ~bSpinLockGaurd() {
+        b_spin_unlock(*m_lock);
+    }
+private:
+    butil::static_atomic<unsigned char> *m_lock; 
+};
+
+
+#endif  //BTHREAD_SPIN_LOCK_H

--- a/src/bthread/spinlock.h
+++ b/src/bthread/spinlock.h
@@ -1,6 +1,6 @@
 // spin lock - user lib spin lock.caller should pass lock when init
 // carefully use this,as conflict will cause high cost
-// Copyright (c) 2018 Bigo, Inc.
+// Copyright (c) 2018 abstraction No Inc  
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bthread/task_meta.h
+++ b/src/bthread/task_meta.h
@@ -56,6 +56,9 @@ struct TaskMeta {
     // The thread is interrupted and should wake up from some blocking ops.
     bool interrupted;
 
+    // The thread should ignore interrupted when in some no inter op like in queued mutex,this flag is seted by bthread in wait_queue and bthread_stop use it
+    bool ignore_interrupted;
+
     // Scheduling of the thread can be delayed.
     bool about_to_quit;
     

--- a/src/bthread/types.h
+++ b/src/bthread/types.h
@@ -162,6 +162,21 @@ typedef struct {
 } bthread_mutexattr_t;
 
 typedef struct {
+    unsigned* butex;
+    bthread_contention_site_t csite;
+    bthread_t next_bid;     //just for check
+} bthread_queue_mutex_t;
+
+typedef struct {
+} bthread_queue_mutexattr_t;
+
+struct QueuedMutexInternal {                                                                                        
+    butil::static_atomic<unsigned char> locked;                                                                     
+    butil::static_atomic<unsigned char> guarantee_lock;   //a spin lock protect queue                               
+    unsigned short wait_count;     //concurrence for this queue mutex,not use yet,as overflow is not easy to handle,use wake_up 0 instead         
+};    
+
+typedef struct {
     bthread_mutex_t* m;
     int* seq;
 } bthread_cond_t;

--- a/src/bthread/types.h
+++ b/src/bthread/types.h
@@ -164,7 +164,7 @@ typedef struct {
 typedef struct {
     unsigned* butex;
     bthread_contention_site_t csite;
-    bthread_t next_bid;     //just for check
+    butil::static_atomic<uint64_t> next_bid;   //just for check 
 } bthread_queue_mutex_t;
 
 typedef struct {

--- a/test/BUILD
+++ b/test/BUILD
@@ -220,6 +220,8 @@ cc_test(
         "bthread_dispatcher_unittest.cpp",
         "bthread_fd_unittest.cpp",
         "bthread_mutex_unittest.cpp",
+        "bthread_queue_mutex_unittest.cpp",
+        "bthread_barrel_unittest.cpp",
         "bthread_setconcurrency_unittest.cpp",
         # glog CHECK die with a fatal error
         "bthread_key_unittest.cpp"

--- a/test/bthread_barrel_unittest.cpp
+++ b/test/bthread_barrel_unittest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Bigo, Inc.
+// Copyright (c) 2018 abstraction No Inc 
 // Author: hairet (hairet@vip.qq.com)
 // Date: 2018/11/10 
 

--- a/test/bthread_barrel_unittest.cpp
+++ b/test/bthread_barrel_unittest.cpp
@@ -46,7 +46,7 @@ void* barreler(void* arg) {
     p_arg->run_idx_tid[run_idx] = (long)gettid();
     printf("[%" PRIu64 "] I'm here barreler, uid:%lld, run_idx:%d, reg_idx:%d %" PRId64 "ms\n",
                pthread_numeric_id(), (long long int)p_arg->uid, run_idx, reg_idx, butil::cpuwide_time_ms() - start_time);
-    bthread_usleep(50000);
+    bthread_usleep(100000);
     printf("[%" PRIu64 "] I'm exit barreler, uid:%lld, run_idx:%d, reg_idx:%d %" PRId64 "ms\n",
                pthread_numeric_id(), (long long int)p_arg->uid, run_idx, reg_idx, butil::cpuwide_time_ms() - start_time);
     bthread::UinBarrel::GetInstance()->UnLockUinBarrel(p_arg->uid);

--- a/test/bthread_barrel_unittest.cpp
+++ b/test/bthread_barrel_unittest.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2018 Bigo, Inc.
+// Author: hairet (hairet@vip.qq.com)
+// Date: 2018/11/10 
+
+#include <gtest/gtest.h>
+#include "butil/compat.h"
+#include "butil/time.h"
+#include "butil/macros.h"
+#include "butil/string_printf.h"
+#include "butil/logging.h"
+#include "bthread/bthread.h"
+#include "bthread/butex.h"
+#include "bthread/task_control.h"
+#include "bthread/barrel.h" 
+#include "butil/gperftools_profiler.h"
+#include <sys/types.h>
+#include <map>
+#include <vector>
+
+#define gettid() syscall(__NR_gettid) 
+
+using namespace std;
+
+int c = 0;
+int register_idx = 0;
+
+#define MAX_THREAD 1000
+
+long register_idx_tid[2][MAX_THREAD] = {0};
+long run_idx_tid[2][MAX_THREAD] = {0};
+
+long start_time = butil::cpuwide_time_ms();
+
+struct t_arg {
+    uint64_t uid;
+    long *register_idx_tid;
+    long *run_idx_tid;
+};
+
+void* barreler(void* arg) {
+    t_arg *p_arg = (t_arg *)arg;
+    int reg_idx = ++register_idx;
+    bthread::UinBarrel::GetInstance()->LockUinBarrel(p_arg->uid);
+    int run_idx = ++c;
+    p_arg->register_idx_tid[reg_idx] = (long)gettid();
+    p_arg->run_idx_tid[run_idx] = (long)gettid();
+    printf("[%" PRIu64 "] I'm here barreler, uid:%lld, run_idx:%d, reg_idx:%d %" PRId64 "ms\n",
+               pthread_numeric_id(), (long long int)p_arg->uid, run_idx, reg_idx, butil::cpuwide_time_ms() - start_time);
+    bthread_usleep(50000);
+    printf("[%" PRIu64 "] I'm exit barreler, uid:%lld, run_idx:%d, reg_idx:%d %" PRId64 "ms\n",
+               pthread_numeric_id(), (long long int)p_arg->uid, run_idx, reg_idx, butil::cpuwide_time_ms() - start_time);
+    bthread::UinBarrel::GetInstance()->UnLockUinBarrel(p_arg->uid);
+    return NULL;
+}
+
+TEST(BthreadBarrelTest, sanity) {
+    uint64_t uid1 = 1357890;
+    uint64_t uid2 = 1357891;
+    pthread_t th[8];
+    t_arg arg[8];
+    for (size_t i = 0; i < ARRAY_SIZE(th); ++i) {
+        arg[i].uid = ((i%2==0)?uid1:uid2);
+        arg[i].register_idx_tid = register_idx_tid[i%2];
+        arg[i].run_idx_tid = run_idx_tid[i%2];
+        ASSERT_EQ(0, pthread_create(&th[i], NULL, barreler, &arg[i]));
+        usleep(1500);  //sleep make pthread create and in barrel 
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(th); ++i) {
+        pthread_join(th[i], NULL);
+    }
+    for(unsigned int k = 0; k<2; ++k) {
+        for(unsigned int i = 1; i<ARRAY_SIZE(th)+1 && i<MAX_THREAD; ++i) {
+            ASSERT_EQ(register_idx_tid[k][i], run_idx_tid[k][i]);
+        }
+    }
+}
+
+

--- a/test/bthread_mutex_unittest.cpp
+++ b/test/bthread_mutex_unittest.cpp
@@ -214,6 +214,10 @@ TEST(MutexTest, performance) {
     bthread::Mutex bth_mutex;
     PerfTest(&bth_mutex, (pthread_t*)NULL, thread_num, pthread_create, pthread_join);
     PerfTest(&bth_mutex, (bthread_t*)NULL, thread_num, bthread_start_background, bthread_join);
+
+    //add test 1 for compare
+    PerfTest(&bth_mutex, (pthread_t*)NULL, 1, pthread_create, pthread_join);
+    PerfTest(&bth_mutex, (bthread_t*)NULL, 1, bthread_start_background, bthread_join);
 }
 
 void* loop_until_stopped(void* arg) {

--- a/test/bthread_queue_mutex_unittest.cpp
+++ b/test/bthread_queue_mutex_unittest.cpp
@@ -1,0 +1,304 @@
+// Copyright (c) 2018 Bigo, Inc.
+// Author: hairet (hairet@vip.qq.com)
+// Date: 2018/11/10 
+
+#include <gtest/gtest.h>
+#include "butil/compat.h"
+#include "butil/time.h"
+#include "butil/macros.h"
+#include "butil/string_printf.h"
+#include "butil/logging.h"
+#include "bthread/bthread.h"
+#include "bthread/butex.h"
+#include "bthread/task_control.h"
+#include "bthread/mutex.h"
+#include "butil/gperftools_profiler.h"
+
+namespace {
+inline unsigned* get_butex(bthread_queue_mutex_t& m) {
+    return m.butex;
+}
+
+long start_time = butil::cpuwide_time_ms();
+int c = 0;
+int register_idx = 0;
+void* locker(void* arg) {
+    bthread_queue_mutex_t * m = (bthread_queue_mutex_t *)arg;
+    int reg_idx = ++register_idx;
+    bthread_queue_mutex_lock(m);
+    int run_idx = ++c;
+    printf("[%" PRIu64 "] I'm here queue locker, run_idx:%d, reg_idx:%d %" PRId64 "ms\n", 
+           pthread_numeric_id(), run_idx, reg_idx, butil::cpuwide_time_ms() - start_time);
+    bthread_usleep(5000);
+    bthread_queue_mutex_unlock(m);
+    return NULL;
+}
+
+struct try_lock_t {
+    int running;
+    bthread_queue_mutex_t *m;
+};
+
+void* try_locker(void *arg) {
+    try_lock_t *t = (try_lock_t*)arg;
+    int ret = -1;
+    while(t->running) {
+        ret = bthread_queue_mutex_trylock(t->m);
+        if(0 == ret) {
+            //loop until try is onwer
+            break;
+        }
+    }
+    printf("[%" PRIu64 "] I'm here trying locker, is_onwer:%d, run_idx:%d, %" PRId64 "ms\n",
+        pthread_numeric_id(), (!ret?1:0), ++c, butil::cpuwide_time_ms() - start_time);
+    if(0 == ret) {
+        bthread_queue_mutex_unlock(t->m);
+    }
+    return NULL;
+}
+
+int unorder_c = 0;
+int unorder_register_idx = 0;
+void* unorder_locker(void* arg) {
+    bthread_mutex_t* m = (bthread_mutex_t*)arg;
+    int reg_idx = ++unorder_register_idx;
+    bthread_mutex_lock(m);
+    int run_idx = ++unorder_c; 
+    printf("[%" PRIu64 "] I'm here, unorder locker , run_idx:%d,reg_idx:%d  %" PRId64 "ms\n", 
+            pthread_numeric_id(), run_idx, reg_idx, butil::cpuwide_time_ms() - start_time);
+    bthread_usleep(5000);
+    bthread_mutex_unlock(m);
+    return NULL;
+}
+
+struct try_unorder_lock_t {
+    int running;
+    bthread_mutex_t *m;
+};
+
+void* try_unoreder_locker(void *arg) {
+    try_unorder_lock_t* t = (try_unorder_lock_t *)arg;
+    int ret = -1;
+    while(t->running) {
+        ret = bthread_mutex_trylock(t->m);
+        if(0 == ret) {
+            //loop until try is onwer
+            break;
+        }
+    }
+    printf("[%" PRIu64 "] I'm here trying unoreder locker, is_onwer:%d, run_idx:%d, %" PRId64 "ms\n",
+        pthread_numeric_id(), (!ret?1:0), ++unorder_c, butil::cpuwide_time_ms() - start_time);
+    if(0 == ret) {
+        bthread_mutex_unlock(t->m);
+    }
+    return NULL;
+}
+
+TEST(QueueMutexTest, sanity) {
+    bthread_queue_mutex_t m;
+    ASSERT_EQ(0, bthread_queue_mutex_init(&m, NULL));
+    ASSERT_EQ(0u, *get_butex(m));
+    ASSERT_EQ(0, bthread_queue_mutex_lock(&m));
+    ASSERT_EQ(1u, *get_butex(m));
+    bthread_t th1;
+    ASSERT_EQ(0, bthread_start_urgent(&th1, NULL, locker, &m));
+    usleep(5000); // wait for locker to run.
+    ASSERT_EQ(1u, *get_butex(m)); //if competitor is try lock and do adding wait queue, will be 257u  
+    ASSERT_EQ(0, bthread_queue_mutex_unlock(&m));
+    ASSERT_EQ(0, bthread_join(th1, NULL));
+    ASSERT_EQ(0u, *get_butex(m));
+    ASSERT_EQ(0, bthread_queue_mutex_destroy(&m));
+}
+
+TEST(QueueMutexTest, used_in_pthread) {
+    bthread_queue_mutex_t m;
+    ASSERT_EQ(0, bthread_queue_mutex_init(&m, NULL));
+    pthread_t th[8];
+    for (size_t i = 0; i < ARRAY_SIZE(th); ++i) {
+        ASSERT_EQ(0, pthread_create(&th[i], NULL, locker, &m));
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(th); ++i) {
+        pthread_join(th[i], NULL);
+    }
+    ASSERT_EQ(0u, *get_butex(m));
+    ASSERT_EQ(0, bthread_queue_mutex_destroy(&m));
+}
+
+TEST(QueueMutexTest, queue_order_test_bthread_pthread) {
+    bthread_queue_mutex_t m;
+    ASSERT_EQ(0, bthread_queue_mutex_init(&m, NULL));
+    ASSERT_EQ(0, bthread_queue_mutex_lock(&m));
+    pthread_t th[8];   
+    for (size_t i = 0; i < ARRAY_SIZE(th); ++i) {
+        ASSERT_EQ(0, pthread_create(&th[i], NULL, locker, &m));
+        usleep(2000);  //sleep make pthread create and lock in wait queue by order
+    }
+    bthread_t bth[8];
+    for (size_t i = 0; i < ARRAY_SIZE(bth); ++i) {
+        ASSERT_EQ(0, bthread_start_urgent(&bth[i], NULL, locker, &m));
+        usleep(2000);  //sleep make bthread create and lock in wait queue by order
+    }
+    usleep(5000); // wait for all 8 pthread and 8 bthread locker to run.
+    pthread_t try_th;
+    try_lock_t t;
+    t.running = 1;
+    t.m = &m;
+    ASSERT_EQ(0, pthread_create(&try_th, NULL, try_locker, &t));
+
+    printf("queue_order_test_bthread_pthread release mutex for order test\n");
+    ASSERT_EQ(0, bthread_queue_mutex_unlock(&m));
+    //here we expect locker fun in bthread\pthread run with same reg_idx and run_idx
+
+    usleep(500000);           //wait for some queue locker done
+    t.running = 0;          //no competitor now
+    ASSERT_EQ(0, pthread_join(try_th, NULL) );
+    for (size_t i = 0; i < ARRAY_SIZE(th); ++i) {
+        ASSERT_EQ(0, pthread_join(th[i], NULL) );
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(bth); ++i) {
+        ASSERT_EQ(0, bthread_join(bth[i], NULL));
+    }
+    ASSERT_EQ(0, bthread_queue_mutex_destroy(&m));
+}
+
+TEST(QueueMutexTest, queue_unorder_test_bthread_pthread) {
+    bthread_mutex_t m;
+    ASSERT_EQ(0, bthread_mutex_init(&m, NULL));
+    ASSERT_EQ(0, bthread_mutex_lock(&m));
+    pthread_t th[8];   
+    for (size_t i = 0; i < ARRAY_SIZE(th); ++i) {
+        ASSERT_EQ(0, pthread_create(&th[i], NULL, unorder_locker, &m));
+        usleep(2000);  //sleep make pthread create and lock in wait queue by order
+    }
+    bthread_t bth[8];
+    for (size_t i = 0; i < ARRAY_SIZE(bth); ++i) {
+        ASSERT_EQ(0, bthread_start_urgent(&bth[i], NULL, unorder_locker, &m));
+        usleep(2000);  //sleep make bthread create and lock in wait queue by order
+    }
+    usleep(5000); // wait for all 8 pthread and 8 bthread locker to run.
+    pthread_t try_th;
+    try_unorder_lock_t t;
+    t.running = 1;
+    t.m = &m;
+    ASSERT_EQ(0, pthread_create(&try_th, NULL, try_unoreder_locker, &t));
+
+    printf("queue_unorder_test_bthread_pthread release mutex for unorder test\n");
+    ASSERT_EQ(0, bthread_mutex_unlock(&m));
+    //here we expect locker fun in bthread\pthread run with diff reg_idx and run_idx,most likely happen reg_idx 1 with a big run_idx
+
+    usleep(500000);           //wait for some queue locker done
+    t.running = 0;          //no competitor now
+    ASSERT_EQ(0, pthread_join(try_th, NULL) );
+    for (size_t i = 0; i < ARRAY_SIZE(th); ++i) {
+        ASSERT_EQ(0, pthread_join(th[i], NULL) );
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(bth); ++i) {
+        ASSERT_EQ(0, bthread_join(bth[i], NULL));
+    }
+    ASSERT_EQ(0, bthread_mutex_destroy(&m));
+}
+
+bool g_started = false;
+bool g_stopped = false;
+
+struct BAIDU_CACHELINE_ALIGNMENT PerfArgs {
+    bthread_queue_mutex_t* mutex;
+    int64_t counter;
+    int64_t elapse_ns;
+    bool ready;
+
+    PerfArgs() : mutex(NULL), counter(0), elapse_ns(0), ready(false) {}
+};
+
+void* add_with_mutex(void* void_arg) {
+    PerfArgs* args = (PerfArgs*)void_arg;
+    args->ready = true;
+    butil::Timer t;
+    while (!g_stopped) {
+        if (g_started) {
+            break;
+        }
+        bthread_usleep(1000);
+    }
+    t.start();
+    while (!g_stopped) {
+        bthread_queue_mutex_lock(args->mutex);
+        bthread_queue_mutex_unlock(args->mutex);
+        ++args->counter;
+    }
+    t.stop();
+    args->elapse_ns = t.n_elapsed();
+    return NULL;
+}
+
+int g_prof_name_counter = 0;
+
+template <typename ThreadId,
+         typename ThreadCreateFn, typename ThreadJoinFn>
+void PerfTest(bthread_queue_mutex_t* mutex,
+        ThreadId* /*dummy*/,
+        int thread_num,
+        const ThreadCreateFn& create_fn,
+        const ThreadJoinFn& join_fn) {
+    g_started = false;
+    g_stopped = false;
+    ThreadId threads[thread_num];
+    std::vector<PerfArgs> args(thread_num);
+    for (int i = 0; i < thread_num; ++i) {
+        args[i].mutex = mutex;
+        create_fn(&threads[i], NULL, add_with_mutex, &args[i]);
+    }
+    while (true) {
+        bool all_ready = true;
+        for (int i = 0; i < thread_num; ++i) {
+            if (!args[i].ready) {
+                all_ready = false;
+                break;
+            }
+        }
+        if (all_ready) {
+            break;
+        }
+        usleep(1000);
+    }
+    g_started = true;
+    char prof_name[32];
+    snprintf(prof_name, sizeof(prof_name), "mutex_perf_%d.prof", ++g_prof_name_counter);
+    ProfilerStart(prof_name);
+    usleep(500 * 1000);
+    ProfilerStop();
+    g_stopped = true;
+    int64_t wait_time = 0;
+    int64_t count = 0;
+    for (int i = 0; i < thread_num; ++i) {
+        join_fn(threads[i], NULL);
+        wait_time += args[i].elapse_ns;
+        count += args[i].counter;
+    }
+    LOG(INFO) << "queue_bthread_mutex in "
+        << ((void*)create_fn == (void*)pthread_create ? "pthread" : "bthread")
+        << " thread_num=" << thread_num
+        << " count=" << count
+        << " average_time=" << wait_time / (double)count;
+}
+
+
+TEST(QueueMutexTest, performance) {
+    int thread_num = 12;
+    bthread_queue_mutex_t bth_queue_mutex;
+    ASSERT_EQ(0, bthread_queue_mutex_init(&bth_queue_mutex, NULL));
+    PerfTest(&bth_queue_mutex, (pthread_t*)NULL, thread_num, pthread_create, pthread_join);
+    PerfTest(&bth_queue_mutex, (bthread_t*)NULL, thread_num, bthread_start_background, bthread_join);
+
+    thread_num = 5;
+    PerfTest(&bth_queue_mutex, (pthread_t*)NULL, thread_num, pthread_create, pthread_join);
+    PerfTest(&bth_queue_mutex, (bthread_t*)NULL, thread_num, bthread_start_background, bthread_join);
+    
+    thread_num = 1;
+    PerfTest(&bth_queue_mutex, (pthread_t*)NULL, thread_num, pthread_create, pthread_join);
+    PerfTest(&bth_queue_mutex, (bthread_t*)NULL, thread_num, bthread_start_background, bthread_join);
+
+    ASSERT_EQ(0, bthread_queue_mutex_destroy(&bth_queue_mutex));
+}
+
+} // namespace

--- a/test/bthread_queue_mutex_unittest.cpp
+++ b/test/bthread_queue_mutex_unittest.cpp
@@ -263,7 +263,7 @@ void PerfTest(bthread_queue_mutex_t* mutex,
     }
     g_started = true;
     char prof_name[32];
-    snprintf(prof_name, sizeof(prof_name), "mutex_perf_%d.prof", ++g_prof_name_counter);
+    snprintf(prof_name, sizeof(prof_name), "queue_mutex_perf_%d.prof", ++g_prof_name_counter);
     ProfilerStart(prof_name);
     usleep(500 * 1000);
     ProfilerStop();

--- a/test/bthread_queue_mutex_unittest.cpp
+++ b/test/bthread_queue_mutex_unittest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Bigo, Inc.
+// Copyright (c) 2018 abstraction No Inc
 // Author: hairet (hairet@vip.qq.com)
 // Date: 2018/11/10 
 


### PR DESCRIPTION
sometimes,we needs serilazition for same uid,so queue mutex would be neccessary.and I support queue mutex and uid barrel without affect currenct code.and baidu protocol can enable this by setting brpc::ServerOptions::use_uid_barrel=true(default is false)
queue mutex and barrel with unnitest,and performance explain in mutex.h