### PR TITLE
Feature: Add always_print_primitive_fields flags into Controller and …

### DIFF
--- a/src/brpc/controller.h
+++ b/src/brpc/controller.h
@@ -132,6 +132,7 @@ friend void policy::ProcessThriftRequest(InputMessageBase*);
     static const uint32_t FLAGS_REQUEST_WITH_AUTH = (1 << 15);
     static const uint32_t FLAGS_PB_JSONIFY_EMPTY_ARRAY = (1 << 16);
     static const uint32_t FLAGS_ENABLED_CIRCUIT_BREAKER = (1 << 17);
+    static const uint32_t FLAGS_ALWAYS_PRINT_PRIMITIVE_FIELDS = (1 << 18);
     
 public:
     Controller();
@@ -296,6 +297,14 @@ public:
     // of json in HTTP response.
     void set_pb_jsonify_empty_array(bool f) { set_flag(FLAGS_PB_JSONIFY_EMPTY_ARRAY, f); }
     bool has_pb_jsonify_empty_array() const { return has_flag(FLAGS_PB_JSONIFY_EMPTY_ARRAY); }
+    
+    // Whether to always print primitive fields. By default proto3 primitive
+    // fields with default values will be omitted in JSON output. For example, an
+    // int32 field set to 0 will be omitted. Set this flag to true will override
+    // the default behavior and print primitive fields regardless of their values.
+    void set_always_print_primitive_fields(bool f) { set_flag(FLAGS_ALWAYS_PRINT_PRIMITIVE_FIELDS, f); }
+    bool has_always_print_primitive_fields() const { return has_flag(FLAGS_ALWAYS_PRINT_PRIMITIVE_FIELDS); }
+    
 
     // Tell RPC that done of the RPC can be run in the same thread where
     // the RPC is issued, otherwise done is always run in a different thread.

--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -509,6 +509,8 @@ void SerializeHttpRequest(butil::IOBuf* /*not used*/,
             json2pb::Pb2JsonOptions opt;
             opt.bytes_to_base64 = cntl->has_pb_bytes_to_base64();
             opt.jsonify_empty_array = cntl->has_pb_jsonify_empty_array();
+            opt.always_print_primitive_fields = cntl->has_always_print_primitive_fields();
+            
             opt.enum_option = (FLAGS_pb_enum_as_number
                                ? json2pb::OUTPUT_ENUM_BY_NUMBER
                                : json2pb::OUTPUT_ENUM_BY_NAME);
@@ -749,6 +751,7 @@ HttpResponseSender::~HttpResponseSender() {
             json2pb::Pb2JsonOptions opt;
             opt.bytes_to_base64 = cntl->has_pb_bytes_to_base64();
             opt.jsonify_empty_array = cntl->has_pb_jsonify_empty_array();
+            opt.always_print_primitive_fields = cntl->has_always_print_primitive_fields();
             opt.enum_option = (FLAGS_pb_enum_as_number
                                ? json2pb::OUTPUT_ENUM_BY_NUMBER
                                : json2pb::OUTPUT_ENUM_BY_NAME);

--- a/src/json2pb/pb_to_json.cpp
+++ b/src/json2pb/pb_to_json.cpp
@@ -24,7 +24,8 @@ Pb2JsonOptions::Pb2JsonOptions()
 #else
     , bytes_to_base64(true)
 #endif
-    , jsonify_empty_array(false) {
+    , jsonify_empty_array(false)
+    , always_print_primitive_fields(false) {
 }
 
 class PbToJsonConverter {
@@ -88,7 +89,10 @@ bool PbToJsonConverter::Convert(const google::protobuf::Message& message, Handle
                 _error = "Missing required field: " + field->full_name();
                 return false;
             }
-            continue;
+            
+            if(!_option.always_print_primitive_fields)
+                continue;
+               
         } else if (field->is_repeated()
                    && reflection->FieldSize(message, field) == 0
                    && !_option.jsonify_empty_array) {

--- a/src/json2pb/pb_to_json.cpp
+++ b/src/json2pb/pb_to_json.cpp
@@ -89,10 +89,10 @@ bool PbToJsonConverter::Convert(const google::protobuf::Message& message, Handle
                 _error = "Missing required field: " + field->full_name();
                 return false;
             }
-            
-            if(!_option.always_print_primitive_fields)
+            // Whether dumps default fields
+            if (!_option.always_print_primitive_fields) {
                 continue;
-               
+            }
         } else if (field->is_repeated()
                    && reflection->FieldSize(message, field) == 0
                    && !_option.jsonify_empty_array) {

--- a/src/json2pb/pb_to_json.h
+++ b/src/json2pb/pb_to_json.h
@@ -43,6 +43,12 @@ struct Pb2JsonOptions {
     // to a empty array of json when this option is turned on.
     // Default: false
     bool jsonify_empty_array;
+    
+    // Whether to always print primitive fields. By default proto3 primitive
+    // fields with default values will be omitted in JSON output. For example, an
+    // int32 field set to 0 will be omitted. Set this flag to true will override
+    // the default behavior and print primitive fields regardless of their values.
+    bool always_print_primitive_fields;
 };
 
 // Convert protobuf `messge' to `json' according to `options'.


### PR DESCRIPTION
Add always_print_primitive_fields flags into Controller and json2pb::Pb2JsonOptions.

When serialize protobuf3 into json default fields do not dumps; this can be done by setting always_print_primitive_fields to true.