### PR TITLE
fix discovery docancel request return error response

### DIFF
--- a/src/brpc/policy/discovery_naming_service.cpp
+++ b/src/brpc/policy/discovery_naming_service.cpp
@@ -365,6 +365,7 @@ int DiscoveryClient::DoCancel() const {
     Controller cntl;
     cntl.http_request().set_method(HTTP_METHOD_POST);
     cntl.http_request().uri() = "/discovery/cancel";
+    cntl.http_request().set_content_type("application/x-www-form-urlencoded");
     butil::IOBufBuilder os;
     os << "appid=" << _appid
         << "&hostname=" << _hostname


### PR DESCRIPTION
Discovery服务DoCancel请求，如果不指定Content-Type: application/x-www-form-urlencoded,返回的结果为两个Object，Discovery服务端这样返回也很怪异。