### PR TITLE
fix h2 big response not sending bug

### DIFF
--- a/src/brpc/policy/http2_rpc_protocol.cpp
+++ b/src/brpc/policy/http2_rpc_protocol.cpp
@@ -1522,18 +1522,9 @@ H2UnsentRequest::AppendAndDestroySelf(butil::IOBuf* out, Socket* socket) {
                  << " h2req=" << (StreamUserData*)this;
         return butil::Status(EH2RUNOUTSTREAMS, "Fail to allocate stream_id");
     }
-    H2StreamContext* sctx = _sctx.release();
-    sctx->Init(ctx, id);
-    const int rc = ctx->TryToInsertStream(id, sctx);
-    if (rc < 0) {
-        delete sctx;
-        return butil::Status(EINTERNAL, "Fail to insert existing stream_id");
-    } else if (rc > 0) {
-        delete sctx;
-        return butil::Status(ELOGOFF, "the connection just issued GOAWAY");
-    }
-    _stream_id = sctx->stream_id();
 
+    std::unique_ptr<H2StreamContext> sctx(std::move(_sctx));
+    sctx->Init(ctx, id);
     // flow control
     if (!_cntl->request_attachment().empty()) {
         const int64_t data_size = _cntl->request_attachment().size();
@@ -1541,6 +1532,16 @@ H2UnsentRequest::AppendAndDestroySelf(butil::IOBuf* out, Socket* socket) {
             return butil::Status(ELIMIT, "remote_window_left is not enough, data_size=%" PRId64, data_size);
         }
     }
+
+    const int rc = ctx->TryToInsertStream(id, sctx.get());
+    if (rc < 0) {
+        return butil::Status(EINTERNAL, "Fail to insert existing stream_id");
+    } else if (rc > 0) {
+        return butil::Status(ELOGOFF, "the connection just issued GOAWAY");
+    }
+    _stream_id = sctx->stream_id();
+    // After calling TryToInsertStream, ownership of sctx is transferred to ctx
+    sctx.release();
 
     HPacker& hpacker = ctx->hpacker();
     butil::IOBufAppender appender;


### PR DESCRIPTION
* 当h2response的包体长度小于remote window size时，当前的做法是直接return，导致client无法收到response。
spec中并未说明此情况的做法，一个办法是直接返回RST_STREAM，即此次pr的解决方案。另一种方案是等到收到WINDOW_UPDATE后重试，需要额外的设计和实现。
* 修复sending时的memory leak