### PR TITLE
Fix http verbose memory leak

### DIFF
--- a/src/brpc/details/http_message.h
+++ b/src/brpc/details/http_message.h
@@ -122,7 +122,7 @@ private:
 
 protected:
     // Only valid when -http_verbose is on
-    butil::IOBufBuilder* _vmsgbuilder;
+    std::unique_ptr<butil::IOBufBuilder> _vmsgbuilder;
     size_t _vbodylen;
 };
 

--- a/src/brpc/policy/http2_rpc_protocol.cpp
+++ b/src/brpc/policy/http2_rpc_protocol.cpp
@@ -1285,10 +1285,10 @@ int H2StreamContext::ConsumeHeaders(butil::IOBufBytesIterator& it) {
         }
 
         if (FLAGS_http_verbose) {
-            butil::IOBufBuilder* vs = this->_vmsgbuilder;
+            butil::IOBufBuilder* vs = this->_vmsgbuilder.get();
             if (vs == NULL) {
                 vs = new butil::IOBufBuilder;
-                this->_vmsgbuilder = vs;
+                this->_vmsgbuilder.reset(vs);
                 if (_conn_ctx->is_server_side()) {
                     *vs << "[ H2 REQUEST @" << butil::my_ip() << " ]";
                 } else {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

rpc失败了，导致HttpMessage提前析构，不一定会delete _vmsgbuilder，有可能导致_vmsgbuilder泄露。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
