### PR TITLE
Bugfix: Butex returned to ObjectPool triggers use-after-poison

### DIFF
--- a/src/bthread/butex.cpp
+++ b/src/bthread/butex.cpp
@@ -122,6 +122,17 @@ struct BAIDU_CACHELINE_ALIGNMENT Butex {
 BAIDU_CASSERT(offsetof(Butex, value) == 0, offsetof_value_must_0);
 BAIDU_CASSERT(sizeof(Butex) == BAIDU_CACHELINE_SIZE, butex_fits_in_one_cacheline);
 
+} // namespace bthread
+
+namespace butil {
+// Butex object returned to the ObjectPool<Butex> may be accessed,
+// so ObjectPool<Butex> can not poison the memory region of Butex.
+template <>
+struct ObjectPoolWithASanPoison<bthread::Butex> : false_type {};
+} // namespace butil
+
+namespace bthread {
+
 static void wakeup_pthread(ButexPthreadWaiter* pw) {
     // release fence makes wait_pthread see changes before wakeup.
     pw->sig.store(PTHREAD_SIGNALLED, butil::memory_order_release);

--- a/src/bthread/execution_queue_inl.h
+++ b/src/bthread/execution_queue_inl.h
@@ -587,7 +587,7 @@ inline int ExecutionQueueBase::dereference() {
 }  // namespace bthread
 
 namespace butil {
-// `TaskNode::cancel' may access the TaskNode object returned to the ObjectPool<TaskNode>,
+// TaskNode::cancel() may access the TaskNode object returned to the ObjectPool<TaskNode>,
 // so ObjectPool<TaskNode> can not poison the memory region of TaskNode.
 template <>
 struct ObjectPoolWithASanPoison<bthread::TaskNode> : false_type {};


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2890

Problem Summary:

### What is changed and the side effects?

Changed:

Butex object returned to the ObjectPool<Butex> may be accessed, so ObjectPool<Butex> can not poison the memory region of Butex.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
