### PR TITLE
Bugfix: Signal Trace mode may send SIGURG to wrong thread

### DIFF
--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -19,6 +19,7 @@
 
 // Date: Tue Jul 10 17:40:58 CST 2012
 
+#include <pthread.h>
 #include <sys/syscall.h>                   // SYS_gettid
 #include "butil/scoped_lock.h"             // BAIDU_SCOPED_LOCK
 #include "butil/errno.h"                   // berror
@@ -90,7 +91,7 @@ void* TaskControl::worker_thread(void* arg) {
         return NULL;
     }
 
-    g->_tid = syscall(SYS_gettid);
+    g->_tid = pthread_self();
 
     std::string worker_thread_name = butil::string_printf(
         "brpc_wkr:%d-%d", g->tag(),

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -1107,7 +1107,7 @@ void print_task(std::ostream& os, bthread_t tid) {
     TaskStatistics stat = {0, 0, 0};
     TaskStatus status = TASK_STATUS_UNKNOWN;
     bool traced = false;
-    pid_t worker_tid = 0;
+    pthread_t worker_tid{};
     {
         BAIDU_SCOPED_LOCK(m->version_lock);
         if (given_ver == *m->version_butex) {

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -219,7 +219,7 @@ public:
 
     bthread_tag_t tag() const { return _tag; }
 
-    pid_t tid() const { return _tid; }
+    pthread_t tid() const { return _tid; }
 
     int64_t current_task_cpu_clock_ns() {
         if (_last_cpu_clock_ns == 0) {
@@ -378,7 +378,7 @@ friend class TaskControl;
     bthread_tag_t _tag{BTHREAD_TAG_DEFAULT};
 
     // Worker thread id.
-    pid_t _tid{-1};
+    pthread_t _tid{};
 };
 
 }  // namespace bthread

--- a/src/bthread/task_meta.h
+++ b/src/bthread/task_meta.h
@@ -113,7 +113,7 @@ struct TaskMeta {
     // Whether bthread is traced？
     bool traced{false};
     // Worker thread id.
-    pid_t worker_tid{-1};
+    pthread_t worker_tid{};
 
 public:
     // Only initialize [Not Reset] fields, other fields will be reset in

--- a/src/bthread/task_tracer.h
+++ b/src/bthread/task_tracer.h
@@ -20,15 +20,15 @@
 
 #ifdef BRPC_BTHREAD_TRACER
 
+#include "bthread/mutex.h"
+#include "bthread/task_meta.h"
+#include "butil/intrusive_ptr.hpp"
+#include "butil/shared_object.h"
+#include "butil/strings/safe_sprintf.h"
+#include "butil/synchronization/condition_variable.h"
+#include <libunwind.h>
 #include <signal.h>
 #include <vector>
-#include <libunwind.h>
-#include "butil/synchronization/condition_variable.h"
-#include "butil/intrusive_ptr.hpp"
-#include "butil/strings/safe_sprintf.h"
-#include "butil/shared_object.h"
-#include "bthread/task_meta.h"
-#include "bthread/mutex.h"
 
 namespace bthread {
 
@@ -39,10 +39,10 @@ public:
     bool Init();
     // Set the status to `s'.
     void set_status(TaskStatus s, TaskMeta* meta);
-    static void set_running_status(pid_t worker_tid, TaskMeta* meta);
+    static void set_running_status(pthread_t worker_tid, TaskMeta* meta);
     static bool set_end_status_unsafe(TaskMeta* m);
 
-    // Trace the bthread of `tid'.
+    // Trace the bthread of `tid`.
     std::string Trace(bthread_t tid);
     void Trace(std::ostream& os, bthread_t tid);
 
@@ -103,7 +103,7 @@ private:
 
     static bool RegisterSignalHandler();
     static void SignalHandler(int sig, siginfo_t* info, void* context);
-    Result SignalTrace(pid_t worker_tid);
+    Result SignalTrace(pthread_t worker_tid);
 
     // Make sure only one bthread is traced at a time.
     Mutex _trace_request_mutex;


### PR DESCRIPTION
* Bugfix: Use `rt_tgsigqueueinfo` to send the signal to correct worker thread

### What problem does this PR solve?

Issue Number: fix #3038

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
