### PR TITLE
bazel: add config setting for NO_PTHREAD_MUTEX_HOOK

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -53,6 +53,9 @@ COPTS = [
 }) + select({
     "//bazel/config:brpc_with_asan": ["-fsanitize=address"],
     "//conditions:default": [""],
+}) + select({
+    "//bazel/config:brpc_with_no_pthread_mutex_hook": ["-DNO_PTHREAD_MUTEX_HOOK"],
+    "//conditions:default": [""],
 })
 
 LINKOPTS = [

--- a/bazel/config/BUILD.bazel
+++ b/bazel/config/BUILD.bazel
@@ -137,3 +137,9 @@ config_setting(
         "with_bthread_tracer": "true",
     },
 )
+
+config_setting(
+    name = "brpc_with_no_pthread_mutex_hook",
+    define_values = {"BRPC_WITH_NO_PTHREAD_MUTEX_HOOK": "true"},
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:  #2726

Problem Summary: add bazel config setting for `NO_PTHREAD_MUTEX_HOOK` macro.

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
