### PR TITLE
Bugfix: TaskTracer deadlocks due to ABA problem

### DIFF
--- a/src/bthread/task_meta.h
+++ b/src/bthread/task_meta.h
@@ -112,6 +112,8 @@ struct TaskMeta {
     TaskStatus status{TASK_STATUS_UNKNOWN};
     // Whether bthread is traced？
     bool traced{false};
+    // [Not Reset] guarantee tracing completion before jumping.
+    pthread_mutex_t trace_lock{};
     // Worker thread id.
     pthread_t worker_tid{};
 
@@ -122,9 +124,11 @@ public:
         pthread_spin_init(&version_lock, 0);
         version_butex = butex_create_checked<uint32_t>();
         *version_butex = 1;
+        pthread_mutex_init(&trace_lock, NULL);
     }
         
     ~TaskMeta() {
+        pthread_mutex_destroy(&trace_lock);
         butex_destroy(version_butex);
         version_butex = NULL;
         pthread_spin_destroy(&version_lock);

--- a/src/bthread/task_tracer.h
+++ b/src/bthread/task_tracer.h
@@ -47,7 +47,7 @@ public:
     void Trace(std::ostream& os, bthread_t tid);
 
     // When the worker is jumping stack from a bthread to another,
-    void WaitForTracing(TaskMeta* m);
+    static void WaitForTracing(TaskMeta* m);
 
 private:
     // Error number guard used in signal handler.
@@ -94,7 +94,6 @@ private:
         Result result;
     };
 
-    static TaskStatus WaitForJumping(TaskMeta* m);
     Result TraceImpl(bthread_t tid);
 
     unw_cursor_t MakeCursor(bthread_fcontext_t fcontext);
@@ -107,11 +106,6 @@ private:
 
     // Make sure only one bthread is traced at a time.
     Mutex _trace_request_mutex;
-
-    // For signal trace.
-    // Make sure bthread does not jump stack when it is being traced.
-    butil::Mutex _mutex;
-    butil::ConditionVariable _cond{&_mutex};
 
     // For context trace.
     unw_context_t _context{};

--- a/test/brpc_http_rpc_protocol_unittest.cpp
+++ b/test/brpc_http_rpc_protocol_unittest.cpp
@@ -1701,9 +1701,9 @@ TEST_F(HttpTest, spring_protobuf_content_type) {
     res.Clear();
     cntl2.http_request().set_content_type("application/x-protobuf");
     stub.Echo(&cntl2, &req, &res, nullptr);
-    ASSERT_FALSE(cntl.Failed());
+    ASSERT_FALSE(cntl2.Failed());
     ASSERT_EQ(EXP_RESPONSE, res.message());
-    ASSERT_EQ("application/x-protobuf", cntl.http_response().content_type());
+    ASSERT_EQ("application/x-protobuf", cntl2.http_response().content_type());
 }
 
 TEST_F(HttpTest, dump_http_request) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
https://github.com/apache/brpc/issues/2983#issuecomment-3388228204
https://github.com/apache/brpc/issues/2983#issuecomment-3394061697

### What is changed and the side effects?

Changed:

1. Not to support the tracing of bthread in TASK_STATUS_JUMPING status and just return an error msg like below, instead of waiting for jumping.
2. Taskmeta has its lock for waiting for tracing, to avoid starvation of bthread jumping caused by new tracing.
3. WaitForTracing acquire the lock, indicating that tracing is complete, so no condition variable is needed.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
