### PR TITLE
Fix: Remove recursion of redis command parser

### DIFF
--- a/src/brpc/redis_command.h
+++ b/src/brpc/redis_command.h
@@ -43,6 +43,12 @@ butil::Status RedisCommandByComponents(butil::IOBuf* buf,
                                       const butil::StringPiece* components,
                                       size_t num_components);
 
+enum RedisCommandConsumeState {
+    CONSUME_STATE_CONTINUE,
+    CONSUME_STATE_DONE,
+    CONSUME_STATE_ERROR,
+};
+
 // A parser used to parse redis raw command.
 class RedisCommandParser {
 public:
@@ -58,6 +64,14 @@ public:
 private:
     // Reset parser to the initial state.
     void Reset();
+
+    // Consume one arg from `buf'. 
+    // Return CONSUME_STATE_CONTINUE if the parser needs more data. 
+    // Return CONSUME_STATE_DONE if the parser has parsed a complete command.
+    // Return CONSUME_STATE_ERROR if the parser meets an error.
+    RedisCommandConsumeState ConsumeImpl(butil::IOBuf& buf,
+                                         butil::Arena* arena,
+                                         ParseError* err);
 
     bool _parsing_array;            // if the parser has met array indicator '*'
     int _length;                    // array length


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:  NULL 

Problem Summary: Remove recursion of redis command parser

### What is changed and the side effects?

Changed: Convert RedisCommandParser::Consume to iterative state machine (remove recursion)

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
