### PR TITLE
Fix bvar's bad return value

### DIFF
--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -107,7 +107,7 @@ static bool read_proc_status(ProcStat &stat) {
             ",tpgid,flags,pri,nice | tail -n1", (long)pid);
     if (butil::read_command_output(oss, cmdbuf) != 0) {
         LOG(ERROR) << "Fail to read stat";
-        return -1;
+        return false;
     }
     const std::string& result = oss.str();
     if (sscanf(result.c_str(), "%d %d %d %d"
@@ -230,7 +230,7 @@ static bool read_proc_memory(ProcMemory &m) {
     snprintf(cmdbuf, sizeof(cmdbuf), "ps -p %ld -o rss=,vsz=", (long)pid);
     if (butil::read_command_output(oss, cmdbuf) != 0) {
         LOG(ERROR) << "Fail to read memory state";
-        return -1;
+        return false;
     }
     const std::string& result = oss.str();
     if (sscanf(result.c_str(), "%ld %ld", &m.resident, &m.size) != 2) {
@@ -292,7 +292,7 @@ static bool read_load_average(LoadAverage &m) {
     std::ostringstream oss;
     if (butil::read_command_output(oss, "sysctl -n vm.loadavg") != 0) {
         LOG(ERROR) << "Fail to read loadavg";
-        return -1;
+        return false;
     }
     const std::string& result = oss.str();
     if (sscanf(result.c_str(), "{ %lf %lf %lf }",


### PR DESCRIPTION
### What problem does this PR solve?
Resolve issue: #3152 
Problem Summary:
Fix bug.
When read stat(such as proc, memory and load) failed, we need to return false, but return -1 now, which is true instead.
### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
