### PR TITLE
Bugfix: data race issue exists in the message processing process

### DIFF
--- a/src/brpc/event_dispatcher.h
+++ b/src/brpc/event_dispatcher.h
@@ -226,6 +226,7 @@ public:
     int AddConsumer(int fd) {
         if (!_init) {
             LOG(ERROR) << "IOEvent has not been initialized";
+            errno = EINVAL;
             return -1;
         }
         return GetGlobalEventDispatcher(fd, _bthread_tag)

--- a/src/brpc/rdma/rdma_endpoint.cpp
+++ b/src/brpc/rdma/rdma_endpoint.cpp
@@ -278,7 +278,7 @@ static void TryReadOnTcpDuringRdmaEst(Socket* s) {
                 return;
             }
             if (!s->MoreReadEvents(&progress)) {
-                break;
+                return;
             }
         } else if (nr == 0) {
             s->SetEOF();
@@ -332,7 +332,7 @@ void RdmaEndpoint::OnNewDataFromTcp(Socket* m) {
             return;
         }
         if (!m->MoreReadEvents(&progress)) {
-            break;
+            return;
         }
     }
 }
@@ -1418,7 +1418,7 @@ void RdmaEndpoint::PollCq(Socket* m) {
                 continue;
             }
             if (!m->MoreReadEvents(&progress)) {
-                break;
+                return;
             }
             if (ep->GetAndAckEvents() < 0) {
                 s->SetFailed(errno, "Fail to ack CQ event on %s",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #2265 , resolve #2814

Problem Summary:

Messages should not be processed after no events have occurred. Otherwise, multi-threaded operations on `_read_buf` may cause a data race problem.

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
