### PR TITLE
Support dynamic expansion of RDMA block pool

### DIFF
--- a/src/brpc/rdma/block_pool.h
+++ b/src/brpc/rdma/block_pool.h
@@ -80,8 +80,7 @@ bool InitBlockPool(RegisterCallback cb);
 // FLAGS_rdma_memory_pool_user_specified_memory is true, user is  responsibility
 // of extending memory blocks , this ensuring flexibility for advanced use
 // cases.
-void* ExtendBlockPoolByUser(void* region_base, size_t region_size,
-                            int block_type);
+void* ExtendBlockPoolByUser(void* region_base, size_t region_size, int block_type);
 
 // Allocate a buf with length at least @a size (require: size>0)
 // Return the address allocated, NULL if failed and errno is set.

--- a/src/butil/memory/scope_guard.h
+++ b/src/butil/memory/scope_guard.h
@@ -104,4 +104,6 @@ operator+(ScopeExitHelper, Callback&& callback) {
   auto BRPC_ANONYMOUS_VARIABLE(SCOPE_EXIT) =                \
       ::butil::internal::ScopeExitHelper() + [&]() noexcept
 
+#define BUTIL_SCOPE_EXIT BRPC_SCOPE_EXIT
+
 #endif // BUTIL_SCOPED_GUARD_H


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: 

Problem Summary:

When `FLAGS_rdma_memory_pool_buckets > 1`, the block pool cannot be dynamically expanded.

### What is changed and the side effects?

Changed:

Dynamically expanded memory is stored in an `expansion_list` protected by `extend_lock`, and each bucket only retrieves memory from the `expansion_list` at the corresponding index.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
