### PR TITLE
Support naming bthread to help debug

### DIFF
--- a/src/brpc/acceptor.cpp
+++ b/src/brpc/acceptor.cpp
@@ -78,6 +78,7 @@ int Acceptor::StartAccept(int listened_fd, int idle_timeout_sec,
     if (idle_timeout_sec > 0) {
         bthread_attr_t tmp = BTHREAD_ATTR_NORMAL;
         tmp.tag = _bthread_tag;
+        bthread_attr_set_name(&tmp, "CloseIdleConnections");
         if (bthread_start_background(&_close_idle_tid, &tmp, CloseIdleConnections, this) != 0) {
             LOG(FATAL) << "Fail to start bthread";
             return -1;

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -743,6 +743,7 @@ END_OF_RPC:
         bthread_t bt;
         bthread_attr_t attr = (FLAGS_usercode_in_pthread ?
                                BTHREAD_ATTR_PTHREAD : BTHREAD_ATTR_NORMAL);
+        bthread_attr_set_name(&attr, "RunEndRPC");
         _tmp_completion_info = info;
         if (bthread_start_background(&bt, &attr, RunEndRPC, this) != 0) {
             LOG(FATAL) << "Fail to start bthread";

--- a/src/brpc/event_dispatcher_epoll.cpp
+++ b/src/brpc/event_dispatcher_epoll.cpp
@@ -78,6 +78,7 @@ int EventDispatcher::Start(const bthread_attr_t* thread_attr) {
     // Only event dispatcher thread has flag BTHREAD_GLOBAL_PRIORITY.
     bthread_attr_t epoll_thread_attr =
         _thread_attr | BTHREAD_NEVER_QUIT | BTHREAD_GLOBAL_PRIORITY;
+    bthread_attr_set_name(&epoll_thread_attr, "EventDispatcher::RunThis");
 
     // Polling thread uses the same attr for consumer threads (NORMAL right
     // now). Previously, we used small stack (32KB) which may be overflowed

--- a/src/brpc/event_dispatcher_kqueue.cpp
+++ b/src/brpc/event_dispatcher_kqueue.cpp
@@ -78,6 +78,7 @@ int EventDispatcher::Start(const bthread_attr_t* thread_attr) {
     // Only event dispatcher thread has flag BTHREAD_GLOBAL_PRIORITY.
     bthread_attr_t kqueue_thread_attr =
         _thread_attr | BTHREAD_NEVER_QUIT | BTHREAD_GLOBAL_PRIORITY;
+    bthread_attr_set_name(&kqueue_thread_attr, "EventDispatcher::RunThis");
 
     // Polling thread uses the same attr for consumer threads (NORMAL right
     // now). Previously, we used small stack (32KB) which may be overflowed

--- a/src/brpc/global.cpp
+++ b/src/brpc/global.cpp
@@ -635,7 +635,9 @@ static void GlobalInitializeOrDieImpl() {
 
     // We never join GlobalUpdate, let it quit with the process.
     bthread_t th;
-    CHECK(bthread_start_background(&th, NULL, GlobalUpdate, NULL) == 0)
+    bthread_attr_t attr = BTHREAD_ATTR_NORMAL;
+    bthread_attr_set_name(&attr, "GlobalUpdate");
+    CHECK(bthread_start_background(&th, &attr, GlobalUpdate, NULL) == 0)
         << "Fail to start GlobalUpdate";
 }
 

--- a/src/brpc/periodic_task.cpp
+++ b/src/brpc/periodic_task.cpp
@@ -38,8 +38,10 @@ static void* PeriodicTaskThread(void* arg) {
 
 static void RunPeriodicTaskThread(void* arg) {
     bthread_t th = 0;
+    bthread_attr_t attr = BTHREAD_ATTR_NORMAL;
+    bthread_attr_set_name(&attr, "PeriodicTaskThread");
     int rc = bthread_start_background(
-        &th, &BTHREAD_ATTR_NORMAL, PeriodicTaskThread, arg);
+        &th, &attr, PeriodicTaskThread, arg);
     if (rc != 0) {
         LOG(ERROR) << "Fail to start PeriodicTaskThread";
         static_cast<PeriodicTask*>(arg)->OnDestroyingTask();

--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -1236,6 +1236,7 @@ int Server::StartInternal(const butil::EndPoint& endpoint,
     CHECK_EQ(INVALID_BTHREAD, _derivative_thread);
     bthread_attr_t tmp = BTHREAD_ATTR_NORMAL;
     tmp.tag = _options.bthread_tag;
+    bthread_attr_set_name(&tmp, "UpdateDerivedVars");
     if (bthread_start_background(&_derivative_thread, &tmp,
                                  UpdateDerivedVars, this) != 0) {
         LOG(ERROR) << "Fail to create _derivative_thread";

--- a/src/brpc/socket_map.cpp
+++ b/src/brpc/socket_map.cpp
@@ -190,7 +190,9 @@ int SocketMap::Init(const SocketMapOptions& options) {
     }
     if (_options.idle_timeout_second_dynamic != NULL ||
         _options.idle_timeout_second > 0) {
-        if (bthread_start_background(&_close_idle_thread, NULL,
+        bthread_attr_t attr = BTHREAD_ATTR_NORMAL;
+        bthread_attr_set_name(&attr, "RunWatchConnections");
+        if (bthread_start_background(&_close_idle_thread, &attr,
                                      RunWatchConnections, this) != 0) {
             LOG(FATAL) << "Fail to start bthread";
             return -1;

--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -669,3 +669,10 @@ uint64_t bthread_cpu_clock_ns(void) {
 }
 
 }  // extern "C"
+
+void bthread_attr_set_name(bthread_attr_t* attr, const char* name) {
+    if (attr) {
+        strncpy(attr->name, name, BTHREAD_NAME_MAX_LENGTH);
+        attr->name[BTHREAD_NAME_MAX_LENGTH] = '\0';
+    }
+}

--- a/src/bthread/fd.cpp
+++ b/src/bthread/fd.cpp
@@ -141,8 +141,10 @@ public:
             PLOG(FATAL) << "Fail to epoll_create/kqueue";
             return -1;
         }
+        bthread_attr_t attr = BTHREAD_ATTR_NORMAL;
+        bthread_attr_set_name(&attr, "EpollThread::run_this");
         if (bthread_start_background(
-                &_tid, NULL, EpollThread::run_this, this) != 0) {
+                &_tid, &attr, EpollThread::run_this, this) != 0) {
             close(_epfd);
             _epfd = -1;
             LOG(FATAL) << "Fail to create epoll bthread";

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -49,7 +49,7 @@
 namespace bthread {
 
 static const bthread_attr_t BTHREAD_ATTR_TASKGROUP = {
-    BTHREAD_STACKTYPE_UNKNOWN, 0, NULL, BTHREAD_TAG_INVALID };
+    BTHREAD_STACKTYPE_UNKNOWN, 0, NULL, BTHREAD_TAG_INVALID, {0} };
 
 DEFINE_bool(show_bthread_creation_in_vars, false, "When this flags is on, The time "
             "from bthread creation to first run will be recorded and shown in /vars");
@@ -1141,6 +1141,7 @@ void print_task(std::ostream& os, bthread_t tid, bool enable_trace,
            << "\nattr={stack_type=" << attr.stack_type
            << " flags=" << attr.flags
            << " specified_tag=" << attr.tag
+           << " name=" << attr.name
            << " keytable_pool=" << attr.keytable_pool
            << "}\nhas_tls=" << has_tls
            << "\nuptime_ns=" << butil::cpuwide_time_ns() - cpuwide_start_ns

--- a/src/bthread/types.h
+++ b/src/bthread/types.h
@@ -97,12 +97,14 @@ typedef struct {
     size_t nfree;
 } bthread_keytable_pool_stat_t;
 
+static const size_t BTHREAD_NAME_MAX_LENGTH = 31;
 // Attributes for thread creation.
 typedef struct bthread_attr_t {
     bthread_stacktype_t stack_type;
     bthread_attrflags_t flags;
     bthread_keytable_pool_t* keytable_pool;
     bthread_tag_t tag;
+    char name[BTHREAD_NAME_MAX_LENGTH + 1]; // do not use std::string to keep POD
 
 #if defined(__cplusplus)
     void operator=(unsigned stacktype_and_flags) {
@@ -120,6 +122,8 @@ typedef struct bthread_attr_t {
 #endif  // __cplusplus
 } bthread_attr_t;
 
+void bthread_attr_set_name(bthread_attr_t* attr, const char* name);
+
 // bthreads started with this attribute will run on stack of worker pthread and
 // all bthread functions that would block the bthread will block the pthread.
 // The bthread will not allocate its own stack, simply occupying a little meta
@@ -127,22 +131,22 @@ typedef struct bthread_attr_t {
 // obvious drawback is that you need more worker pthreads when you have a lot
 // of such bthreads.
 static const bthread_attr_t BTHREAD_ATTR_PTHREAD =
-{ BTHREAD_STACKTYPE_PTHREAD, 0, NULL, BTHREAD_TAG_INVALID };
+{ BTHREAD_STACKTYPE_PTHREAD, 0, NULL, BTHREAD_TAG_INVALID, {0} };
 
 // bthreads created with following attributes will have different size of
 // stacks. Default is BTHREAD_ATTR_NORMAL.
 static const bthread_attr_t BTHREAD_ATTR_SMALL = {BTHREAD_STACKTYPE_SMALL, 0, NULL,
-                                                  BTHREAD_TAG_INVALID};
+                                                  BTHREAD_TAG_INVALID, {0}};
 static const bthread_attr_t BTHREAD_ATTR_NORMAL = {BTHREAD_STACKTYPE_NORMAL, 0, NULL,
-                                                   BTHREAD_TAG_INVALID};
+                                                   BTHREAD_TAG_INVALID, {0}};
 static const bthread_attr_t BTHREAD_ATTR_LARGE = {BTHREAD_STACKTYPE_LARGE, 0, NULL,
-                                                  BTHREAD_TAG_INVALID};
+                                                  BTHREAD_TAG_INVALID, {0}};
 
 // bthreads created with this attribute will print log when it's started,
 // context-switched, finished.
 static const bthread_attr_t BTHREAD_ATTR_DEBUG = {
     BTHREAD_STACKTYPE_NORMAL, BTHREAD_LOG_START_AND_FINISH | BTHREAD_LOG_CONTEXT_SWITCH, NULL,
-    BTHREAD_TAG_INVALID};
+    BTHREAD_TAG_INVALID, {0}};
 
 static const size_t BTHREAD_EPOLL_THREAD_NUM = 1;
 static const bthread_t BTHREAD_ATOMIC_INIT = 0;


### PR DESCRIPTION
The bthread name is shown when checking bthread status by curl ip:port/bthreads/xxx, which helps to debug when bthread trace is not enabled.

### What problem does this PR solve?

Issue Number:  enhancement for #3088 

Problem Summary:

### What is changed and the side effects?

Changed:
add `name` field in bthread_attr_t and set name when creating bthread

Side effects:
- Performance effects: NO

- Breaking backward compatibility: NO

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
