### PR TITLE
Fix: Add missed definition of RegisterFlagValidatorOrDie for uint32_t

### DIFF
--- a/src/brpc/reloadable_flags.cpp
+++ b/src/brpc/reloadable_flags.cpp
@@ -66,6 +66,10 @@ bool RegisterFlagValidatorOrDie(const int32_t* flag,
                                 bool (*validate_fn)(const char*, int32_t)) {
     return butil::RegisterFlagValidatorOrDieImpl(flag, validate_fn);
 }
+bool RegisterFlagValidatorOrDie(const uint32_t* flag,
+                                bool (*validate_fn)(const char*, uint32_t)) {
+    return butil::RegisterFlagValidatorOrDieImpl(flag, validate_fn);
+}
 bool RegisterFlagValidatorOrDie(const int64_t* flag,
                                 bool (*validate_fn)(const char*, int64_t)) {
     return butil::RegisterFlagValidatorOrDieImpl(flag, validate_fn);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
