### PR TITLE
fix gdb_bthread_stack bthread_begin error

### DIFF
--- a/tools/gdb_bthread_stack.py
+++ b/tools/gdb_bthread_stack.py
@@ -55,8 +55,8 @@ bthreads = []
 status = False
 
 def get_bthread_num():
-    root_agent = gdb.parse_and_eval("&(((((*bthread::g_task_control)._nbthreads)._combiner)._agents).root_)")
-    global_res = int(gdb.parse_and_eval("((*bthread::g_task_control)._nbthreads)._combiner._global_result"))
+    root_agent = gdb.parse_and_eval("&(((*(((*bthread::g_task_control)._nbthreads)._combiner._M_ptr))._agents).root_)")
+    global_res = int(gdb.parse_and_eval("(*(((*bthread::g_task_control)._nbthreads)._combiner._M_ptr))._global_result"))
     get_agent = "(*(('bvar::detail::AgentCombiner<long, long, bvar::detail::AddTo<long> >::Agent' *){}))"
     last_node = root_agent
     long_type = gdb.lookup_type("long")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #3149

Problem Summary: python exception no member or method named _agents when using gdb_bthread_stack.py

### What is changed and the side effects?

Changed: root_agent nad global_res

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
