### PR TITLE
Fix compile issue when the linking project is using C++23

### DIFF
--- a/src/brpc/redis.cpp
+++ b/src/brpc/redis.cpp
@@ -101,10 +101,10 @@ bool RedisRequest::AddCommand(const butil::StringPiece& command) {
         CHECK(st.ok()) << st;
         _has_error = true;
         return false;
-    }    
+    }
 }
 
-bool RedisRequest::AddCommandByComponents(const butil::StringPiece* components, 
+bool RedisRequest::AddCommandByComponents(const butil::StringPiece* components,
                                          size_t n) {
     if (_has_error) {
         return false;
@@ -117,7 +117,7 @@ bool RedisRequest::AddCommandByComponents(const butil::StringPiece* components,
         CHECK(st.ok()) << st;
         _has_error = true;
         return false;
-    }        
+    }
 }
 
 bool RedisRequest::AddCommandWithArgs(const char* fmt, ...) {
@@ -356,7 +356,7 @@ bool RedisService::AddCommandHandler(const std::string& name, RedisCommandHandle
     _command_map[lcname] = handler;
     return true;
 }
- 
+
 RedisCommandHandler* RedisService::FindCommandHandler(const butil::StringPiece& name) const {
     auto it = _command_map.find(name.as_string());
     if (it != _command_map.end()) {
@@ -371,6 +371,11 @@ RedisCommandHandler* RedisCommandHandler::NewTransactionHandler() {
 }
 
 // ========== impl of RedisConnContext ==========
+RedisConnContext::RedisConnContext(const RedisService* rs)
+        : redis_service(rs)
+        , batched_size(0)
+        , session(nullptr) {}
+
 RedisConnContext::~RedisConnContext() { }
 
 void RedisConnContext::Destroy() {

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -217,10 +217,7 @@ class RedisCommandParser;
 // This class is as parsing_context in socket.
 class RedisConnContext : public Destroyable  {
 public:
-    explicit RedisConnContext(const RedisService* rs)
-        : redis_service(rs)
-        , batched_size(0)
-        , session(nullptr) {}
+    explicit RedisConnContext(const RedisService* rs);
 
     ~RedisConnContext();
     // @Destroyable


### PR DESCRIPTION
The root cause is unique_ptr has constexpr destructor since C++23

libcxx/include/__memory/unique_ptr.h:75:19: error: invalid application of 'sizeof' to an incomplete type 'brpc::RedisCommandHandler'
   75 |     static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete type");
      |                   ^~~~~~~~~~~
libcxx/include/__memory/unique_ptr.h:290:7: note: in instantiation of member function 'std::default_delete<brpc::RedisCommandHandler>::operator()' requested here
  290 |       __deleter_(__tmp);
      |       ^
libcxx/include/__memory/unique_ptr.h:259:71: note: in instantiation of member function 'std::unique_ptr<brpc::RedisCommandHandler>::reset' requested here
  259 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 ~unique_ptr() { reset(); }
      |                                                                       ^
src/brpc/redis.h:220:14: note: in instantiation of member function 'std::unique_ptr<brpc::RedisCommandHandler>::~unique_ptr' requested here
  220 |     explicit RedisConnContext(const RedisService* rs)
      |              ^
src/brpc/redis.h:190:7: note: forward declaration of 'brpc::RedisCommandHandler'
  190 | class RedisCommandHandler;

### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
