### PR TITLE
fix: avoid SIGSEGV in read_proc_io during static initialization

### DIFF
--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -22,6 +22,8 @@
 #include <sys/resource.h>                  // getrusage
 #include <dirent.h>                        // dirent
 #include <iomanip>                         // setw
+#include <stdio.h>
+#include <errno.h>
 #if defined(__APPLE__)
 #include <libproc.h>
 #include <sys/resource.h>
@@ -430,7 +432,12 @@ static bool read_proc_io(ProcIO* s) {
 #if defined(OS_LINUX)
     butil::ScopedFILE fp("/proc/self/io", "r");
     if (NULL == fp) {
-        PLOG_ONCE(WARNING) << "Fail to open /proc/self/io";
+        static bool ever_printed_io_err = false;
+        if (!ever_printed_io_err) {
+            fprintf(stderr, "WARNING: Fail to open /proc/self/io, errno=%d. "
+                            "I/O related bvars will be unavailable.\n", errno);
+            ever_printed_io_err = true;
+        }
         return false;
     }
     errno = 0;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve https://github.com/apache/brpc/issues/3183

Problem Summary:
When /proc/self/io is inaccessible, read_proc_io calls PLOG during global static construction. If glog is not yet initialized, it triggers a SIGSEGV.

### What is changed and the side effects?

Changed:
Replace PLOG_ONCE with a guarded fprintf(stderr, ...) to ensure safety during early startup. A static flag is used to maintain the "print once" behavior.

Side effects:
- Performance effects: none

- Breaking backward compatibility: none

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
