### PR TITLE
Fix stream closed before response during batch stream creation

### DIFF
--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -1448,6 +1448,7 @@ void Controller::HandleStreamConnection(Socket *host_socket) {
         auto extra_stream_ids = std::move(*_remote_stream_settings->mutable_extra_stream_ids());
         _remote_stream_settings->clear_extra_stream_ids();
         for (size_t i = 1; i < stream_num; ++i) {
+            if(!ptrs[i]) continue;
             Stream* extra_stream = (Stream *) ptrs[i]->conn();
             _remote_stream_settings->set_stream_id(extra_stream_ids[i - 1]);
             s->SetHostSocket(host_socket);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 
Fixes https://github.com/apache/brpc/pull/2754

Problem Summary:

client 批量创建stream，部分stream可能存在创建成功后马上被close的行为（stream was closed before responded），这种行为在非批量创建场景也是存在的，批量注册场景在Controller::HandleStreamConnection里需要单独处理下。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
