### PR TITLE
prevent indefinite defer-close by checking last_active_time

### DIFF
--- a/docs/cn/client.md
+++ b/docs/cn/client.md
@@ -820,8 +820,9 @@ brpc支持[Streaming RPC](streaming_rpc.md)，这是一种应用层的连接，�
 | Name               | Value | Description                              | Defined At              |
 | ------------------ | ----- | ---------------------------------------- | ----------------------- |
 | defer_close_second | 0     | Defer close of connections for so many seconds even if the connection is not used by anyone. Close immediately for non-positive values | src/brpc/socket_map.cpp |
+| defer_close_respect_idle | false | 当 defer_close_second > 0 时，如果连接在最后一个引用释放时已经闲置超过 defer_close_second，则立刻关闭连接（默认关闭以保持兼容） | src/brpc/socket_map.cpp |
 
-设置后引用计数清0时连接并不会立刻被关闭，而是会等待这么多秒再关闭，如果在这段时间内又有channel引用了这个连接，它会恢复正常被使用的状态。不管channel创建析构有多频率，这个选项使得关闭连接的频率有上限。这个选项的副作用是一些fd不会被及时关闭，如果延时被误设为一个大数值，程序占据的fd个数可能会很大。
+设置后引用计数清0时连接并不会立刻被关闭，而是会等待这么多秒再关闭，如果在这段时间内又有channel引用了这个连接，它会恢复正常被使用的状态。不管channel创建析构有多频率，这个选项使得关闭连接的频率有上限。这个选项的副作用是一些fd不会被及时关闭，如果延时被误设为一个大数值，程序占据的fd个数可能会很大。开启 -defer_close_respect_idle 后，如果连接在最后一个引用释放时已经闲置超过 defer_close_second，则可能会被关闭。
 
 ## 连接的缓冲区大小
 

--- a/docs/en/client.md
+++ b/docs/en/client.md
@@ -717,8 +717,9 @@ Another solution is setting gflag -defer_close_second
 | Name               | Value | Description                              | Defined At              |
 | ------------------ | ----- | ---------------------------------------- | ----------------------- |
 | defer_close_second | 0     | Defer close of connections for so many seconds even if the connection is not used by anyone. Close immediately for non-positive values | src/brpc/socket_map.cpp |
+| defer_close_respect_idle | false | When defer_close_second > 0, close a connection immediately when the last reference is removed and the socket has already been idle for longer than defer_close_second | src/brpc/socket_map.cpp |
 
-After setting, connection is not closed immediately after last referential count, instead it will be closed after so many seconds. If a channel references the connection again during the wait, the connection resumes to normal. No matter how frequent channels are created, this flag limits the frequency of closing connections. Side effect of the flag is that file descriptors are not closed immediately after destroying of channels, if the flag is wrongly set to be large, number of active file descriptors in the process may be large as well.
+After setting, connection is not closed immediately after last referential count, instead it will be closed after so many seconds. If a channel references the connection again during the wait, the connection resumes to normal. No matter how frequent channels are created, this flag limits the frequency of closing connections. Side effect of the flag is that file descriptors are not closed immediately after destroying of channels, if the flag is wrongly set to be large, number of active file descriptors in the process may be large as well. When -defer_close_respect_idle is enabled, a connection that has already been idle for longer than defer_close_second may be closed when the last reference is removed.
 
 ## Buffer size of connections
 

--- a/src/brpc/socket_map.h
+++ b/src/brpc/socket_map.h
@@ -154,6 +154,14 @@ struct SocketMapOptions {
     // Default: 0 (disabled)
     const int* defer_close_second_dynamic;
     int defer_close_second;
+
+    // When defer_close_second > 0 and this flag is true, close a connection
+    // immediately when the last reference is removed and the socket has already
+    // been idle for longer than defer_close_second.
+    // If defer_close_respect_idle_dynamic is not NULL, use the dereferenced
+    // value each time.
+    // Default: NULL (treated as false)
+    const bool* defer_close_respect_idle_dynamic;
 };
 
 // Share sockets to the same EndPoint.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

在 SocketMap 里决定“是否进入 defer_close 倒计时”时，不再无条件                             
  defer，而是先看该连接最近一次读/写的活跃时间。                                                                                                              
                                                                                                                                                              
  • 具体改动：当 ref_count 归零准备移除连接时，只有在“连接最近仍有活跃（last_active_time_us 距今不超过 defer_close_second）”的情况下，才把 no_ref_us          
  置为当前时间、开始倒计时；如果连接其实已经闲置超过 defer_close_second，则直接从 socket_map 删除并释放 socket 引用（src/brpc/socket_map.cpp:293）。          
  • 意图：避免老 socket 在“channel 频繁创建/析构导致 ref_count 归零又很快被重新引用”的场景下反复刷新倒计时，从而把一个已经长期不活跃/可能已失败的连接在       
  socket_map 里拖很久，导致新连接迟迟不创建、请求持续复用老连接并依赖其健康检查重连（进而在重连慢时持续失败）。       


### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
