### PR TITLE
fix: remove references to non-existent tracked_objects.h in platform_thread_freebsd.cc

### DIFF
--- a/src/butil/threading/platform_thread_freebsd.cc
+++ b/src/butil/threading/platform_thread_freebsd.cc
@@ -13,7 +13,6 @@
 #include "butil/safe_strerror_posix.h"
 #include "butil/threading/thread_id_name_manager.h"
 #include "butil/threading/thread_restrictions.h"
-#include "butil/tracked_objects.h"
 
 #if !defined(OS_NACL)
 #include <sys/resource.h>
@@ -46,7 +45,6 @@ int ThreadNiceValue(ThreadPriority priority) {
 // static
 void PlatformThread::SetName(const char* name) {
   ThreadIdNameManager::GetInstance()->SetName(CurrentId(), name);
-  tracked_objects::ThreadData::InitializeThreadContext(name);
 
   SetNameSimple(name);
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

`platform_thread_freebsd.cc` includes `butil/tracked_objects.h` and calls
`tracked_objects::ThreadData::InitializeThreadContext(name)`, but this header
and class were part of Chromium's base library profiling subsystem and were
never ported to brpc. This causes a compile error on FreeBSD:

```
fatal error: 'butil/tracked_objects.h' file not found
```

The Linux (`platform_thread_linux.cc`) and macOS (`platform_thread_mac.mm`)
equivalents already had these references removed.

This is PR 1 of 3 for FreeBSD support:
1. **This PR** — Remove dead `tracked_objects.h` references
2. #3224
3. #3225

This first PR is intentionally small to get a feel for the project's review workflow.

### What is changed and the side effects?

Changed:

- Removed `#include "butil/tracked_objects.h"` from `platform_thread_freebsd.cc`
- Removed the call to `tracked_objects::ThreadData::InitializeThreadContext(name)` from `PlatformThread::SetName()`

This is pure dead code removal — the referenced header does not exist anywhere in the brpc source tree.

Side effects:
- Performance effects:
None

- Breaking backward compatibility:
None — the removed code could never have compiled successfully.

---
### Check List:
- Please make sure your changes are compatible.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
