### PR TITLE
feat: improve FreeBSD platform support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,11 @@ endif()
 set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__=__unused__ -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DBRPC_REVISION=\\\"${BRPC_REVISION}\\\" -D__STRICT_ANSI__")
 set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEBUG_SYMBOL} ${THRIFT_CPP_FLAG}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} ${CMAKE_CXX_FLAGS} -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_PTHREAD_MUTEX_HOOK")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNO_PTHREAD_MUTEX_HOOK")
+endif()
 set(CMAKE_C_FLAGS "${CMAKE_CPP_FLAGS} -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-unused-parameter -fno-omit-frame-pointer")
 
 macro(use_cxx11)
@@ -342,6 +347,9 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(DYNAMIC_LIB ${DYNAMIC_LIB} rt)
     set(BRPC_PRIVATE_LIBS "${BRPC_PRIVATE_LIBS} -lrt")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(DYNAMIC_LIB ${DYNAMIC_LIB} execinfo)
+    set(BRPC_PRIVATE_LIBS "${BRPC_PRIVATE_LIBS} -lexecinfo")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(DYNAMIC_LIB ${DYNAMIC_LIB}
         pthread
@@ -500,6 +508,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         ${PROJECT_SOURCE_DIR}/src/butil/strings/sys_string_conversions_mac.mm
         ${PROJECT_SOURCE_DIR}/src/butil/time/time_mac.cc
         ${PROJECT_SOURCE_DIR}/src/butil/mac/scoped_mach_port.cc)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(BUTIL_SOURCES ${BUTIL_SOURCES}
+        ${PROJECT_SOURCE_DIR}/src/butil/threading/platform_thread_freebsd.cc
+        ${PROJECT_SOURCE_DIR}/src/butil/strings/sys_string_conversions_posix.cc)
 endif()
 
 file(GLOB_RECURSE BVAR_SOURCES "${PROJECT_SOURCE_DIR}/src/bvar/*.cpp")

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -1578,7 +1578,7 @@ void Controller::CallAfterRpcResp(const google::protobuf::Message* req, const go
     }
 }
 
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
 typedef sig_t SignalHandler;
 #else
 typedef sighandler_t SignalHandler;

--- a/src/brpc/event_dispatcher.cpp
+++ b/src/brpc/event_dispatcher.cpp
@@ -101,7 +101,7 @@ void IOEventData::BeforeRecycled() {
 
 #if defined(OS_LINUX)
     #include "brpc/event_dispatcher_epoll.cpp"
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
     #include "brpc/event_dispatcher_kqueue.cpp"
 #else
     #error Not implemented

--- a/src/brpc/policy/domain_naming_service.cpp
+++ b/src/brpc/policy/domain_naming_service.cpp
@@ -106,7 +106,7 @@ int DomainNamingService::GetServers(const char* dns_name,
         
     }
 
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
     _aux_buf_len = 0; // suppress unused warning
     // gethostbyname on MAC is thread-safe (with current usage) since the
     // returned hostent is TLS. Check following link for the ref:

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -51,7 +51,7 @@
 #include "brpc/periodic_task.h"
 #include "brpc/details/health_check.h"
 #include "brpc/transport_factory.h"
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
 #include <sys/event.h>
 #endif
 
@@ -676,6 +676,30 @@ void Socket::SetSocketOptions(int fd) {
             PLOG(ERROR) << "Fail to set keepcnt of fd=" << fd;
         }
     }
+#elif defined(OS_FREEBSD)
+    if (_keepalive_options->keepalive_idle_s > 0) {
+        if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,
+                       &_keepalive_options->keepalive_idle_s,
+                       sizeof(_keepalive_options->keepalive_idle_s)) != 0) {
+            PLOG(ERROR) << "Fail to set keepidle of fd=" << fd;
+        }
+    }
+
+    if (_keepalive_options->keepalive_interval_s > 0) {
+        if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL,
+                       &_keepalive_options->keepalive_interval_s,
+                       sizeof(_keepalive_options->keepalive_interval_s)) != 0) {
+            PLOG(ERROR) << "Fail to set keepintvl of fd=" << fd;
+        }
+    }
+
+    if (_keepalive_options->keepalive_count > 0) {
+        if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,
+                       &_keepalive_options->keepalive_count,
+                       sizeof(_keepalive_options->keepalive_count)) != 0) {
+            PLOG(ERROR) << "Fail to set keepcnt of fd=" << fd;
+        }
+    }
 #elif defined(OS_MACOSX)
     if (_keepalive_options->keepalive_idle_s > 0) {
         if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE,
@@ -1265,6 +1289,7 @@ int Socket::Connect(const timespec* abstime,
     CHECK_EQ(0, butil::make_close_on_exec(sockfd));
     // We need to do async connect (to manage the timeout by ourselves).
     CHECK_EQ(0, butil::make_non_blocking(sockfd));
+#if defined(OS_LINUX)
     if (!_device_name.empty()) {
         if (setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
                        _device_name.c_str(), _device_name.size()) < 0) {
@@ -1273,6 +1298,7 @@ int Socket::Connect(const timespec* abstime,
             return -1;
         }
     }
+#endif
     if (local_side().ip != butil::IP_ANY) {
         struct sockaddr_storage cli_addr;
         if (butil::endpoint2sockaddr(local_side(), &cli_addr, &addr_size) != 0) {
@@ -2006,7 +2032,7 @@ int Socket::SSLHandshake(int fd, bool server_mode) {
         case SSL_ERROR_WANT_READ:
 #if defined(OS_LINUX)
             if (bthread_fd_wait(fd, EPOLLIN) != 0) {
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
             if (bthread_fd_wait(fd, EVFILT_READ) != 0) {
 #endif
                 return -1;
@@ -2016,7 +2042,7 @@ int Socket::SSLHandshake(int fd, bool server_mode) {
         case SSL_ERROR_WANT_WRITE:
 #if defined(OS_LINUX)
             if (bthread_fd_wait(fd, EPOLLOUT) != 0) {
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
             if (bthread_fd_wait(fd, EVFILT_WRITE) != 0) {
 #endif
                 return -1;
@@ -2183,7 +2209,7 @@ int Socket::OnInputEvent(void* user_data, uint32_t events,
     if (s->fd() < 0) {
 #if defined(OS_LINUX)
         CHECK(!(events & EPOLLIN)) << "epoll_events=" << events;
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
         CHECK((short)events != EVFILT_READ) << "kqueue filter=" << events;
 #endif
         return -1;
@@ -2406,7 +2432,11 @@ void Socket::DebugSocket(std::ostream& os, SocketId id) {
     {
         int keepidle = 0;
         socklen_t len = sizeof(keepidle);
-#if defined(OS_MACOSX)
+#if defined(OS_FREEBSD)
+        if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, &len) == 0) {
+            os << "\ntcp_keepalive_time=" << keepidle;
+        }
+#elif defined(OS_MACOSX)
         if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &keepidle, &len) == 0) {
             os << "\ntcp_keepalive_time=" << keepidle;
         }
@@ -2420,7 +2450,7 @@ void Socket::DebugSocket(std::ostream& os, SocketId id) {
     {
         int keepintvl = 0;
         socklen_t len = sizeof(keepintvl);
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
         if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, &len) == 0) {
             os << "\ntcp_keepalive_intvl=" << keepintvl;
         }
@@ -2434,7 +2464,7 @@ void Socket::DebugSocket(std::ostream& os, SocketId id) {
     {
         int keepcnt = 0;
         socklen_t len = sizeof(keepcnt);
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
         if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, &len) == 0) {
             os << "\ntcp_keepalive_probes=" << keepcnt;
         }
@@ -2455,7 +2485,22 @@ void Socket::DebugSocket(std::ostream& os, SocketId id) {
     }
 #endif
 
-#if defined(OS_MACOSX)
+#if defined(OS_FREEBSD)
+    struct tcp_info ti;
+    socklen_t len = sizeof(ti);
+    if (fd >= 0 && getsockopt(fd, IPPROTO_TCP, TCP_INFO, &ti, &len) == 0) {
+        os << "\ntcpi={\n  state=" << (uint32_t)ti.tcpi_state
+           << "\n  snd_wscale=" << (uint32_t)ti.tcpi_snd_wscale
+           << "\n  rcv_wscale=" << (uint32_t)ti.tcpi_rcv_wscale
+           << "\n  options=" << (uint32_t)ti.tcpi_options
+           << "\n  rto=" << ti.tcpi_rto
+           << "\n  snd_mss=" << ti.tcpi_snd_mss
+           << "\n  snd_ssthresh=" << ti.tcpi_snd_ssthresh
+           << "\n  snd_cwnd=" << ti.tcpi_snd_cwnd
+           << "\n  rcv_space=" << ti.tcpi_rcv_space
+           << "\n}";
+    }
+#elif defined(OS_MACOSX)
     struct tcp_connection_info ti;
     socklen_t len = sizeof(ti);
     if (fd >= 0 && getsockopt(fd, IPPROTO_TCP, TCP_CONNECTION_INFO, &ti, &len) == 0) {

--- a/src/bthread/context.h
+++ b/src/bthread/context.h
@@ -58,6 +58,15 @@
 	    #define BTHREAD_CONTEXT_CALL_CONVENTION __cdecl
 	#endif
 
+  #elif defined(__FreeBSD__)
+        #ifdef __x86_64__
+            #define BTHREAD_CONTEXT_PLATFORM_linux_x86_64
+            #define BTHREAD_CONTEXT_CALL_CONVENTION
+        #elif __aarch64__
+            #define BTHREAD_CONTEXT_PLATFORM_linux_arm64
+            #define BTHREAD_CONTEXT_CALL_CONVENTION
+        #endif
+
   #elif defined(__APPLE__) && defined(__MACH__)
 	#if defined (__i386__)
 	    #define BTHREAD_CONTEXT_PLATFORM_apple_i386

--- a/src/bthread/errno.cpp
+++ b/src/bthread/errno.cpp
@@ -35,7 +35,7 @@ extern int *__errno_location() __attribute__((__const__));
 int *bthread_errno_location() {
     return __errno_location();
 }
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
 
 extern int * __error(void);
 

--- a/src/bthread/fd.cpp
+++ b/src/bthread/fd.cpp
@@ -22,7 +22,7 @@
 #include "butil/compat.h"
 #include <new>                                   // std::nothrow
 #include <sys/poll.h>                            // poll()
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
 #include <sys/types.h>                           // struct kevent
 #include <sys/event.h>                           // kevent(), kqueue()
 #endif
@@ -133,7 +133,7 @@ public:
         }
 #if defined(OS_LINUX)
         _epfd = epoll_create(epoll_size);
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
         _epfd = kqueue();
 #endif
         _start_mutex.unlock();
@@ -181,7 +181,7 @@ public:
         epoll_event evt = { EPOLLOUT, { NULL } };
         if (epoll_ctl(saved_epfd, EPOLL_CTL_ADD,
                       closing_epoll_pipe[1], &evt) < 0) {
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
         struct kevent kqueue_event;
         EV_SET(&kqueue_event, closing_epoll_pipe[1], EVFILT_WRITE, EV_ADD | EV_ENABLE,
                 0, 0, NULL);
@@ -257,7 +257,7 @@ public:
             return -1;
         }
 # endif
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
         struct kevent kqueue_event;
         EV_SET(&kqueue_event, fd, events, EV_ADD | EV_ENABLE | EV_ONESHOT,
                 0, 0, butex);
@@ -299,7 +299,7 @@ public:
         }
 #if defined(OS_LINUX)
         epoll_ctl(_epfd, EPOLL_CTL_DEL, fd, NULL);
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
         struct kevent evt;
         EV_SET(&evt, fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
         kevent(_epfd, &evt, 1, NULL, 0, NULL);
@@ -325,7 +325,7 @@ private:
         const size_t MAX_EVENTS = 32;
 #if defined(OS_LINUX)
         epoll_event* e = new (std::nothrow) epoll_event[MAX_EVENTS];
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
         typedef struct kevent KEVENT;
         struct kevent* e = new (std::nothrow) KEVENT[MAX_EVENTS];
 #endif
@@ -343,7 +343,7 @@ private:
             const int epfd = _epfd;
 #if defined(OS_LINUX)
             const int n = epoll_wait(epfd, e, MAX_EVENTS, -1);
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
             const int n = kevent(epfd, NULL, 0, e, MAX_EVENTS, NULL);
 #endif
             if (_stop) {
@@ -383,7 +383,7 @@ private:
                 EpollButex* butex = pbutex ?
                     pbutex->load(butil::memory_order_consume) : NULL;
 # endif
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
                 EpollButex* butex = static_cast<EpollButex*>(e[i].udata);
 #endif
                 if (butex != NULL && butex != CLOSING_GUARD) {
@@ -495,7 +495,7 @@ int bthread_connect(int sockfd, const sockaddr* serv_addr,
     }
 #if defined(OS_LINUX)
     if (bthread_fd_wait(sockfd, EPOLLOUT) < 0) {
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
     if (bthread_fd_wait(sockfd, EVFILT_WRITE) < 0) {
 #endif
         return -1;
@@ -531,7 +531,7 @@ int bthread_timed_connect(int sockfd, const struct sockaddr* serv_addr,
     }
 #if defined(OS_LINUX)
     if (bthread_fd_timedwait(sockfd, EPOLLOUT, abstime) < 0) {
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
     if (bthread_fd_timedwait(sockfd, EVFILT_WRITE, abstime) < 0) {
 #endif
         return -1;

--- a/src/bthread/mutex.cpp
+++ b/src/bthread/mutex.cpp
@@ -477,6 +477,12 @@ static void init_sys_mutex_lock() {
     sys_pthread_mutex_lock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_lock");
     sys_pthread_mutex_trylock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_trylock");
     sys_pthread_mutex_unlock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_unlock");
+#elif defined(OS_FREEBSD)
+    sys_pthread_mutex_init = (MutexInitOp)dlsym(RTLD_NEXT, "pthread_mutex_init");
+    sys_pthread_mutex_destroy = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_destroy");
+    sys_pthread_mutex_lock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_lock");
+    sys_pthread_mutex_trylock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_trylock");
+    sys_pthread_mutex_unlock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_unlock");
 #endif
 }
 

--- a/src/bthread/sys_futex.cpp
+++ b/src/bthread/sys_futex.cpp
@@ -25,7 +25,7 @@
 #include <pthread.h>
 #include <unordered_map>
 
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
 
 namespace bthread {
 

--- a/src/bthread/sys_futex.h
+++ b/src/bthread/sys_futex.h
@@ -53,7 +53,7 @@ inline int futex_requeue_private(void* addr1, int nwake, void* addr2) {
 
 }  // namespace bthread
 
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
 
 namespace bthread {
 

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -374,6 +374,14 @@ void TaskControl::bind_thread_to_cpu(pthread_t pthread, unsigned cpu_id) {
             LOG(WARNING) << "Failed to bind thread to cpu: " << cpu_id;
         }
         (void)r;
+#elif defined(OS_FREEBSD)
+        cpuset_t cs;
+        CPU_ZERO(&cs);
+        CPU_SET(cpu_id, &cs);
+        if (cpuset_setaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1,
+                               sizeof(cs), &cs) != 0) {
+            LOG(WARNING) << "Failed to bind thread to cpu: " << cpu_id;
+        }
 #elif defined(OS_MACOSX)
         thread_port_t mach_thread = pthread_mach_thread_np(pthread);
         if (mach_thread != MACH_PORT_NULL) {

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -214,7 +214,7 @@ void TaskGroup::run_main_task() {
         }
         if (FLAGS_show_per_worker_usage_in_vars && !usage_bvar) {
             char name[32];
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
             snprintf(name, sizeof(name), "bthread_worker_usage_%" PRIu64,
                      pthread_numeric_id());
 #else
@@ -251,7 +251,7 @@ TaskGroup::~TaskGroup() {
 
 #ifdef BUTIL_USE_ASAN
 int PthreadAttrGetStack(void*& stack_addr, size_t& stack_size) {
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
     stack_addr = pthread_get_stackaddr_np(pthread_self());
     stack_size = pthread_get_stacksize_np(pthread_self());
     return 0;

--- a/src/butil/compat.h
+++ b/src/butil/compat.h
@@ -66,6 +66,10 @@ __END_DECLS
 
 #include <sys/epoll.h>
 
+#elif defined(OS_FREEBSD)
+
+#include <sys/event.h>
+
 #else
 
 #error "The platform does not support epoll-like APIs"
@@ -81,6 +85,8 @@ inline uint64_t pthread_numeric_id() {
         return id;
     }
     return -1;
+#elif defined(OS_FREEBSD)
+    return (uint64_t)(uintptr_t)pthread_self();
 #else
     return pthread_self();
 #endif

--- a/src/butil/details/extended_endpoint.hpp
+++ b/src/butil/details/extended_endpoint.hpp
@@ -163,7 +163,7 @@ public:
                 eep->_u.in6.sin6_flowinfo = 0u;
                 eep->_u.in6.sin6_scope_id = 0u;
                 eep->_socklen = sizeof(_u.in6);
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
                 eep->_u.in6.sin6_len = eep->_socklen;
 #endif
             }
@@ -177,7 +177,7 @@ public:
                 int size = sp.copy(eep->_u.un.sun_path, sp.size());
                 eep->_u.un.sun_path[size] = '\0';
                 eep->_socklen = offsetof(sockaddr_un, sun_path) + size + 1;
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
                 eep->_u.un.sun_len = eep->_socklen;
 #endif
             }

--- a/src/butil/endpoint.cpp
+++ b/src/butil/endpoint.cpp
@@ -30,7 +30,7 @@
 #include <memory>
 #include <gflags/gflags.h>
 #include <sys/poll.h>
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
 #include <sys/event.h>                           // kevent(), kqueue()
 #endif
 #include "butil/build_config.h"                // OS_MACOSX
@@ -403,7 +403,7 @@ static short epoll_to_poll_events(uint32_t epoll_events) {
     CHECK_EQ((uint32_t)poll_events, epoll_events);
     return poll_events;
 }
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
 short kqueue_to_poll_events(int kqueue_events) {
     //TODO: add more values?
     short poll_events = 0;
@@ -421,7 +421,7 @@ int pthread_fd_wait(int fd, unsigned events,
                     const timespec* abstime) {
 #if defined(OS_LINUX)
     const short poll_events = epoll_to_poll_events(events);
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
     const short poll_events = kqueue_to_poll_events(events);
 #endif
     if (poll_events == 0) {
@@ -482,7 +482,7 @@ int pthread_timed_connect(int sockfd, const struct sockaddr* serv_addr,
     }
 #if defined(OS_LINUX)
     if (pthread_fd_wait(sockfd, EPOLLOUT, abstime) < 0) {
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
     if (pthread_fd_wait(sockfd, EVFILT_WRITE, abstime) < 0) {
 #endif
         return -1;

--- a/src/butil/errno.cpp
+++ b/src/butil/errno.cpp
@@ -52,7 +52,7 @@ int DescribeCustomizedErrno(
             return -1;
         }
     } else {
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
         const int rc = strerror_r(error_code, tls_error_buf, ERROR_BUFSIZE);
         if (rc != EINVAL)
 #else
@@ -79,7 +79,7 @@ const char* berror(int error_code) {
         if (s) {
             return s;
         }
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
         const int rc = strerror_r(error_code, butil::tls_error_buf, butil::ERROR_BUFSIZE);
         if (rc == 0 || rc == ERANGE/*bufsize is not long enough*/) {
             return butil::tls_error_buf;

--- a/src/butil/fd_utility.cpp
+++ b/src/butil/fd_utility.cpp
@@ -24,7 +24,7 @@
 #include <sys/socket.h>              // setsockopt
 #include <netinet/tcp.h>             // TCP_NODELAY
 #include <netinet/tcp.h>
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD)
 #include <netinet/tcp_fsm.h>        // TCPS_ESTABLISHED, TCP6S_ESTABLISHED
 #endif
 #include "butil/logging.h"
@@ -88,6 +88,17 @@ int is_connected(int sockfd) {
         return -1;
     }
     if (ti.tcpi_state != TCP_ESTABLISHED) {
+        errno = ENOTCONN;
+        return -1;
+    }
+#elif defined(OS_FREEBSD)
+    struct tcp_info ti{};
+    socklen_t len = sizeof(ti);
+    if (getsockopt(sockfd, IPPROTO_TCP, TCP_INFO, &ti, &len) < 0) {
+        PLOG(FATAL) << "Fail to getsockopt";
+        return -1;
+    }
+    if (ti.tcpi_state != TCPS_ESTABLISHED) {
         errno = ENOTCONN;
         return -1;
     }

--- a/src/butil/logging.cc
+++ b/src/butil/logging.cc
@@ -129,6 +129,16 @@ DEFINE_bool(print_stack_on_check, true,
             "Print the stack trace when a CHECK was failed");
 BUTIL_VALIDATE_GFLAG(print_stack_on_check, butil::PassValidate);
 
+#if defined(OS_FREEBSD)
+// Rename flags to avoid gflags duplicate registration with system glog.
+// glog defines "v" and "vmodule"; we define "brpc_verbose" and "brpc_vmodule"
+// and create local aliases so brpc code can still use FLAGS_v / FLAGS_vmodule.
+DEFINE_int32(brpc_verbose, 0, "Show all VLOG(m) messages for m <= this."
+               " Overridable by --brpc_vmodule.");
+DEFINE_string(brpc_vmodule, "", "per-module verbose level.");
+#define FLAGS_v FLAGS_brpc_verbose
+#define FLAGS_vmodule FLAGS_brpc_vmodule
+#else
 DEFINE_int32(v, 0, "Show all VLOG(m) messages for m <= this."
              " Overridable by --vmodule.");
 DEFINE_string(vmodule, "", "per-module verbose level."
@@ -136,15 +146,24 @@ DEFINE_string(vmodule, "", "per-module verbose level."
               " MODULE_NAME is a glob pattern, matched against the filename base"
               " (that is, name ignoring .cpp/.h)."
               " LOG_LEVEL overrides any value given by --v.");
+#endif
 
 DEFINE_bool(log_pid, false, "Log process id");
 
 DEFINE_bool(log_bid, true, "Log bthread id");
 
+#if defined(OS_FREEBSD)
+DEFINE_int32(brpc_minloglevel, 0, "Any log at or above this level will be "
+             "displayed. Anything below this level will be silently ignored. "
+             "0=INFO 1=NOTICE 2=WARNING 3=ERROR 4=FATAL");
+BUTIL_VALIDATE_GFLAG(brpc_minloglevel, butil::NonNegativeInteger);
+#define FLAGS_minloglevel FLAGS_brpc_minloglevel
+#else
 DEFINE_int32(minloglevel, 0, "Any log at or above this level will be "
              "displayed. Anything below this level will be silently ignored. "
              "0=INFO 1=NOTICE 2=WARNING 3=ERROR 4=FATAL");
 BUTIL_VALIDATE_GFLAG(minloglevel, butil::NonNegativeInteger);
+#endif
 
 DEFINE_bool(log_hostname, false, "Add host after pid in each log so"
             " that we know where logs came from when using aggregation tools"

--- a/src/butil/popen.cpp
+++ b/src/butil/popen.cpp
@@ -20,6 +20,9 @@
 #include <gflags/gflags.h>
 #include "butil/build_config.h"
 #include "butil/logging.h"
+#if defined(OS_FREEBSD)
+#include <sys/wait.h>
+#endif
 
 #if defined(OS_LINUX)
 // clone is a linux specific syscall

--- a/src/butil/process_util.cc
+++ b/src/butil/process_util.cc
@@ -31,7 +31,10 @@
 #include "butil/process_util.h"
 
 #if defined(OS_MACOSX)
-#include <libproc.h>                   // proc_pidpath
+#include <libproc.h>
+#elif defined(OS_FREEBSD)
+#include <sys/types.h>
+#include <sys/sysctl.h>                   // proc_pidpath
 #endif
 namespace butil {
 
@@ -47,7 +50,7 @@ ssize_t ReadCommandLine(char* buf, size_t len, bool with_args) {
         LOG(ERROR) << "Fail to read /proc/self/cmdline";
         return -1;
     }
-#elif defined(OS_MACOSX)
+#elif defined(OS_MACOSX) || defined(OS_FREEBSD)
     static pid_t pid = getpid();
     std::ostringstream oss;
     char cmdbuf[32];
@@ -97,6 +100,14 @@ ssize_t GetProcessAbsolutePath(char *buf, size_t len) {
     memset(buf, 0, len);
     int ret = proc_pidpath(getpid(), buf, len);
     return ret;
+#elif defined(OS_FREEBSD)
+    memset(buf, 0, len);
+    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+    size_t cb = len;
+    if (sysctl(mib, 4, buf, &cb, NULL, 0) == 0) {
+        return (ssize_t)cb;
+    }
+    return -1;
 #endif
 }
 

--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -449,6 +449,9 @@ static bool read_proc_io(ProcIO* s) {
         return false;
     }
     return true;
+#elif defined(OS_FREEBSD)
+    memset(s, 0, sizeof(ProcIO));
+    return false;
 #elif defined(OS_MACOSX)
     // TODO(zhujiashun): get rchar, wchar, syscr, syscw, cancelled_write_bytes
     // in MacOS.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

brpc has partial FreeBSD support (27 source files already contain `OS_FREEBSD`/`__FreeBSD__` references), but it does not compile or run on FreeBSD. This PR completes that support.

The most critical issue is a **static initialization deadlock**: bthread interposes `pthread_mutex_lock` for contention profiling. On FreeBSD, during early process init, `libc++.so`'s `ios_base::Init::Init()` calls `pthread_mutex_lock` to initialize `std::locale::classic()`. bthread's interposed version calls `pthread_once(init_sys_mutex_lock)`, which itself needs `pthread_mutex_lock` — causing infinite recursion. Without the `NO_PTHREAD_MUTEX_HOOK` fix in this PR, **any FreeBSD application linking brpc will deadlock at startup**.

This is PR 2 of 3 for FreeBSD support:
1. #3223
2. **This PR** — FreeBSD platform support
3. #3225 

### What is changed and the side effects?

Changed:

**All source changes are guarded by `#if defined(OS_FREEBSD)` — zero impact on Linux or macOS builds.** Most changes piggyback on existing macOS/Darwin code paths since both use kqueue.

CMakeLists.txt:
- Add `NO_PTHREAD_MUTEX_HOOK` on FreeBSD to prevent static init deadlock caused by bthread's `pthread_mutex_lock` interposition conflicting with `libc++` `ios_base::Init` during early process initialization
- Add `-lexecinfo` for backtrace support
- Wire existing FreeBSD source files into the build (`platform_thread_freebsd.cc`, `sys_string_conversions_posix.cc` — already present in the tree but not compiled)

Source changes:
- `butil/compat.h`: Add FreeBSD kqueue path and `pthread_getthreadid_np()`
- `butil/process_util.cc`: FreeBSD `ReadCommandLine` via `ps` (like macOS)
- `butil/fd_utility.cpp`: kqueue fd handling
- `butil/logging.cc`: Rename `FLAGS_v`/`vmodule`/`minloglevel` to avoid gflags duplicate registration with system glog on FreeBSD
- `brpc/socket.cpp`: FreeBSD `TCP_INFO` support
- `bthread/`: FreeBSD futex emulation, context switching, fd handling
- `bvar/default_variables.cpp`: FreeBSD `/proc` fallback

Side effects:
- Performance effects:
None — all changes are behind `OS_FREEBSD` guards and do not affect existing platforms.

- Breaking backward compatibility:
None — this is additive FreeBSD support only.

---
### Check List:
- Please make sure your changes are compatible.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
