### PR TITLE
ci: add FreeBSD build CI and glog 0.7.x compatibility

### DIFF
--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -1,0 +1,33 @@
+name: Build on FreeBSD
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  compile-with-cmake:
+    runs-on: ubuntu-latest
+    name: FreeBSD build
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build on FreeBSD
+      uses: vmactions/freebsd-vm@v1
+      with:
+        release: "14.3"
+        usesh: true
+        prepare: |
+          pkg install -y cmake protobuf gflags leveldb openssl git
+
+        run: |
+          set -ex
+          mkdir build && cd build
+          cmake -DCMAKE_PREFIX_PATH=/usr/local ..
+          make -j$(sysctl -n hw.ncpu)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,13 @@ set(WITH_GLOG_VAL "0")
 if(WITH_GLOG)
     set(WITH_GLOG_VAL "1")
     set(BRPC_WITH_GLOG 1)
+    # glog >= 0.7 requires GLOG_USE_GLOG_EXPORT to define GLOG_EXPORT/GLOG_NO_EXPORT.
+    # glog/export.h only exists in glog >= 0.7, so use it as a version check.
+    include(CheckIncludeFileCXX)
+    check_include_file_cxx("glog/export.h" GLOG_HAS_EXPORT_H)
+    if(GLOG_HAS_EXPORT_H)
+        add_definitions(-DGLOG_USE_GLOG_EXPORT)
+    endif()
 endif()
 
 if(WITH_DEBUG_SYMBOLS)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

brpc has CI for Linux and macOS but not FreeBSD. With FreeBSD platform support added in PR #3224, a CI workflow is needed to prevent regressions.

Additionally, glog >= 0.7 requires `GLOG_USE_GLOG_EXPORT` to be defined before including its headers. Without this, builds using newer glog versions fail with:

```
error: <glog/logging.h> was not included correctly.
```

This is PR 3 of 3 for FreeBSD support:
1. #3223
2. #3224 
3. **This PR** — FreeBSD CI + glog 0.7.x compatibility

### What is changed and the side effects?

Changed:

- Added `.github/workflows/ci-freebsd.yml` — GitHub Actions workflow using [vmactions/freebsd-vm](https://github.com/vmactions/freebsd-vm) to build on FreeBSD 14.2. Modeled after the existing `ci-macos.yml`.
- Added conditional `GLOG_USE_GLOG_EXPORT` detection in `CMakeLists.txt` — uses `check_include_file_cxx("glog/export.h")` to detect glog >= 0.7, and only defines `GLOG_USE_GLOG_EXPORT` when the header exists. Safe with older glog versions. Benefits all platforms, not just FreeBSD.

Side effects:
- Performance effects:
None

- Breaking backward compatibility:
None — the glog compatibility change is additive and safe with all glog versions.

---
### Check List:
- Please make sure your changes are compatible.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
