### PR TITLE
Fix use after free issue of EventDispatcher LatencyRecorder

### DIFF
--- a/src/brpc/event_dispatcher.cpp
+++ b/src/brpc/event_dispatcher.cpp
@@ -54,13 +54,11 @@ static void StopAndJoinGlobalDispatchers() {
             g_edisp[i * FLAGS_event_dispatcher_num + j].Join();
         }
     }
-    delete g_edisp_read_lantency;
-    delete g_edisp_write_lantency;
 }
 
 void InitializeGlobalDispatchers() {
-    g_edisp_read_lantency = new bvar::LatencyRecorder("event_dispatcher_read_latency");
-    g_edisp_write_lantency = new bvar::LatencyRecorder("event_dispatcher_write_latency");
+    g_edisp_read_lantency = new bvar::LatencyRecorder("event_dispatcher_read");
+    g_edisp_write_lantency = new bvar::LatencyRecorder("event_dispatcher_write");
 
     g_edisp = new EventDispatcher[FLAGS_task_group_ntags * FLAGS_event_dispatcher_num];
     for (int i = 0; i < FLAGS_task_group_ntags; ++i) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #3265

Problem Summary:

1. Use-After-Free crash on process exit: In `StopAndJoinGlobalDispatchers()` (registered via `atexit`), the global `bvar::LatencyRecorder` pointers `g_edisp_read_lantency` and `g_edisp_write_lantency` are explicitly deleted. However, bvar's background sampler thread (`bvar_sampler_collector`) is a leaky singleton that is never joined or stopped. If the sampler thread is concurrently accessing these recorders when they are deleted, a Use-After-Free occurs. 

2. Unnecessary "latency" prefix stripping in `LatencyRecorder::expose()`.
https://github.com/apache/brpc/blob/be01d1047c45fd679daf2d089c5041b13c5da3cc/src/bvar/latency_recorder.cpp#L198-L205

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
